### PR TITLE
Fixes API discrepancy

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -83,7 +83,7 @@ typealias CL_user_data Any
 
 #TODO: pass user data as Any type 
 @ocl_func_1_0(clCreateContext, CL_context,
-              (CL_context_properties, CL_uint, Ptr{CL_device_id}, CL_callback, CL_user_data, Ptr{CL_int}))
+              (Ptr{CL_context_properties}, CL_uint, Ptr{CL_device_id}, CL_callback, CL_user_data, Ptr{CL_int}))
 
 @ocl_func_1_0(clCreateContextFromType, CL_context,
               (Ptr{CL_context_properties}, CL_device_type, CL_callback, CL_user_data, Ptr{CL_int}))


### PR DESCRIPTION
@SimonDanish found this discrepancy from the OpenCL API.
clCreateContext accepts an Array of CL_context_properties hence we should give it a Ptr like in clCreateContextFromtType.

Also I should propably write a test for that.
