### PR TITLE
simplifies runtest and hopefully fixes travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,15 +13,8 @@ script:
   - julia -e 'Pkg.add("FactCheck");'
   - julia -e 'Pkg.init(); run(`ln -s $(pwd()) $(Pkg.dir())/OpenCL`); Pkg.resolve()'
   - julia -e 'using OpenCL; @assert isdefined(:OpenCL); @assert typeof(OpenCL) === Module'
-  
-  - julia --code-coverage test/test_platform.jl
-  - julia --code-coverage test/test_context.jl
-  - julia --code-coverage test/test_device.jl
-  - julia --code-coverage test/test_buffer.jl
-  - julia --code-coverage test/test_cmdqueue.jl
-  - julia --code-coverage test/test_event.jl
-  - julia --code-coverage test/test_program.jl
-  - julia --code-coverage test/test_kernel.jl
+
+  - julia --code-coverage test/runtests.jl
 
   - julia examples/demo.jl
   - julia examples/performance.jl
@@ -34,7 +27,7 @@ script:
   - julia examples/hands_on_opencl/exA/pi_vocl.jl 1  
   - julia examples/hands_on_opencl/exA/pi_vocl.jl 4  
   - julia examples/hands_on_opencl/exA/pi_vocl.jl 8 
-
+after_success:
   - julia -e 'Pkg.add("Coverage"); using Coverage; Coveralls.submit(Coveralls.process_folder())'
 
 

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,11 +1,9 @@
-testsdir = dirname(Base.source_path())
+module TestOpenCL
+	using FactCheck
 
-for t in [:platform, :context, :device, :cmdqueue, :event, :buffer, :program, :kernel]
-    tfile = joinpath(testsdir, "test_$t.jl")
-    run(`julia $tfile`)
-    # On my crappy laptop, I constantly get "out of host memory" errors
-    # when evaling each file, use eval for faster test execution
-    #evalfile(tfile)
-end
+	@runtest OpenCL test_platform test_context test_device test_cmdqueue test_event test_buffer test_program test_kernel
 
-run(`julia $(joinpath(testsdir, "behavior_tests.jl"))`)
+	@runtest OpenCL behavior_tests
+    exitstatus()
+
+end # module


### PR DESCRIPTION
I changed the way runtest.jl worked like https://github.com/zachallaun/FactCheck.jl recommends and moved Coveralls to the after-success phase.
