### PR TITLE
Macro for extension functions

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -14,14 +14,20 @@ end
     const libopencl = "OpenCL"
 end
 
-macro ocl_func(func, ret_type, arg_types)
+macro ocl_func_base(func, func_name, ret_type, arg_types)
     local args_in = Symbol[symbol("arg$i::$T")
                            for (i, T) in enumerate(arg_types.args)]
     quote 
-        $(esc(func))($(args_in...)) = ccall(($(string(func)), libopencl), 
+        $(esc(func_name))($(args_in...)) = ccall($func, 
                                             $ret_type,
                                             $arg_types,
                                             $(args_in...))
+    end
+end
+
+macro ocl_func(func, ret_type, arg_types)
+    quote
+        @ocl_func_base(($(string(func)), libopencl), $func, $ret_type, $arg_types) 
     end
 end
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -31,6 +31,20 @@ macro ocl_func(func, ret_type, arg_types)
     end
 end
 
+macro ocl_func_extension_1_0(func, ret_type, arg_types)
+    local ptr = clGetExtensionFunctionAddress(string(func))
+    quote
+        @ocl_func_base($ptr, $func, $ret_type, $arg_types) 
+    end
+end
+
+# macro ocl_func_extension_1_2(platform, func, ret_type, arg_types)
+#     local ptr = clGetExtensionFunctionAddressForPlatform($platform, string(func))
+#     quote
+#         @ocl_func_base($ptr, $func, $ret_type, $arg_types) 
+#     end
+# end
+
 macro ocl_func_1_0(func, ret_type, arg_types) 
     quote
         @ocl_func($func, $ret_type, $arg_types)


### PR DESCRIPTION
This pr adds a macro for automatically loading the function pointer for an extensions. This is necessary for #32  to work properly across machines. 

It currently still has the following issues 
- [ ] This only works for OpenCL 1.0-1.1 for OpenCL 1.2 clGetExtensionFunctionAddress has been changed to clGetExtensionFunctionAddressForPlatform
- [ ] OpenCL only guarantees that this will work when the Extension from which the function is actually exists.

It also raises the question how we handle different OpenCL versions.
Maybe we need some conditional loading/code generation on run time via a check in an `__init__` function if the platform only supports OCL1.1 or if it support support OCL1.2.

Also conditional modules like JuliaLang/Julia#6195 would be helpful. 
