### PR TITLE
Tweak tests and fix nothing comparisons

### DIFF
--- a/src/api.jl
+++ b/src/api.jl
@@ -43,7 +43,7 @@ include("api/opencl_2.0.0.jl")
 
 function parse_version(version_string)
     mg = match(r"^OpenCL ([0-9]+)\.([0-9]+) .*$", version_string)
-    if mg == nothing
+    if mg === nothing
         error("Non conforming version string: $(ver)")
     end
     return @compat VersionNumber(parse(Int, mg.captures[1]),

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -90,7 +90,7 @@ end
 function Buffer{T}(::Type{T}, ctx::Context, flags::CL_mem_flags, len::Integer=0;
                    hostbuf::Union(Nothing, Array{T})=nothing)
 
-    if (hostbuf != nothing &&
+    if (hostbuf !== nothing &&
         (flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR)) == 0)
         warn("'hostbuf' was passed, but no memory flags to make use of it")
     end
@@ -102,7 +102,7 @@ function Buffer{T}(::Type{T}, ctx::Context, flags::CL_mem_flags, len::Integer=0;
     nbytes = 0
     retain_buf::Union(Nothing, Array{T}) = nothing
 
-    if hostbuf != nothing
+    if hostbuf !== nothing
         if (flags & CL_MEM_USE_HOST_PTR) != 0
             retain_buf = hostbuf
         end
@@ -124,7 +124,7 @@ function Buffer{T}(::Type{T}, ctx::Context, flags::CL_mem_flags, len::Integer=0;
 
     err_code = Array(CL_int, 1)
     mem_id = api.clCreateBuffer(ctx.id, flags, cl_uint(nbytes),
-                                hostbuf != nothing ? hostbuf : C_NULL,
+                                hostbuf !== nothing ? hostbuf : C_NULL,
                                 err_code)
     if err_code[1] != CL_SUCCESS
         throw(CLError(err_code[1]))
@@ -145,8 +145,8 @@ function enqueue_read_buffer{T}(q::CmdQueue,
                                 dev_offset::Csize_t,
                                 wait_for::Union(Nothing, Vector{Event}),
                                 is_blocking::Bool)
-    n_evts  = @compat wait_for == nothing ? UInt(0) : length(wait_for)
-    evt_ids = wait_for == nothing ? C_NULL  : [evt.id for evt in wait_for]
+    n_evts  = @compat wait_for === nothing ? UInt(0) : length(wait_for)
+    evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
     ret_evt = Array(CL_event, 1)
     nbytes  = sizeof(hostbuf)
     @assert nbytes > 0
@@ -164,8 +164,8 @@ function enqueue_write_buffer{T}(q::CmdQueue,
                                  offset::Csize_t,
                                  wait_for::Union(Nothing, Vector{Event}),
                                  is_blocking::Bool)
-    n_evts  = @compat wait_for == nothing ? UInt(0) : length(wait_for)
-    evt_ids = wait_for == nothing ? C_NULL  : [evt.id for evt in wait_for]
+    n_evts  = @compat wait_for === nothing ? UInt(0) : length(wait_for)
+    evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
     ret_evt = Array(CL_event, 1)
     nbytes  = sizeof(hostbuf)
     @assert nbytes > 0
@@ -183,8 +183,8 @@ function enqueue_copy_buffer{T}(q::CmdQueue,
                                 src_offset::Csize_t,
                                 dst_offset::Csize_t,
                                 wait_for::Union(Nothing, Vector{Event}))
-    n_evts  = @compat wait_for == nothing ? UInt(0) : length(wait_for)
-    evt_ids = wait_for == nothing ? C_NULL  : [evt.id for evt in wait_for]
+    n_evts  = @compat wait_for === nothing ? UInt(0) : length(wait_for)
+    evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
     ret_evt = Array(CL_event, 1)
     if byte_count < 0
         byte_count_src = Array(Csize_t, 1)
@@ -218,7 +218,7 @@ function enqueue_unmap_mem{T}(q::CmdQueue,
     end
     n_evts  = 0
     evt_ids = C_NULL
-    if wait_for != nothing
+    if wait_for !== nothing
         if isa(wait_for, Event)
             n_evts = 1
             evt_ids = [wait_for.id]
@@ -276,8 +276,8 @@ function enqueue_map_mem{T}(q::CmdQueue,
         throw(ArgumentError("Buffer length must be greater than or
                              equal to prod(dims) + offset"))
     end
-    n_evts  = wait_for == nothing ? cl_uint(0) : cl_uint(length(wait_for))
-    evt_ids = wait_for == nothing ? C_NULL  : [evt.id for evt in wait_for]
+    n_evts  = wait_for === nothing ? cl_uint(0) : cl_uint(length(wait_for))
+    evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
     flags   = cl_map_flags(flags)
     offset  = unsigned(offset)
     nbytes  = unsigned(prod(dims) * sizeof(T))
@@ -320,7 +320,7 @@ end
                                     offset::Csize_t, nbytes::Csize_t,
                                     wait_for::Union(Vector{Event}, Nothing))
 
-        if wait_for == nothing
+        if wait_for === nothing
             evt_ids = C_NULL
             n_evts = cl_uint(0)
         else
@@ -339,7 +339,8 @@ end
     # enqueue a fill operation, return an event
     function enqueue_fill{T}(q::CmdQueue, buf::Buffer{T}, x::T)
         nbytes = sizeof(buf)
-        evt = enqueue_fill_buffer(q, buf, x, unsigned(0), unsigned(nbytes), nothing)
+        evt = enqueue_fill_buffer(q, buf, x, unsigned(0),
+                                  unsigned(nbytes), nothing)
         return evt
     end
 
@@ -376,7 +377,8 @@ function copy!{T}(q::CmdQueue, dst::Buffer{T}, src::Buffer{T})
         throw(ArgumentError("Buffers to be copied must be the same size"))
     end
     nbytes = convert(Csize_t, sizeof(src))
-    evt = enqueue_copy_buffer(q, src, dst, nbytes, unsigned(0), unsigned(0), nothing)
+    evt = enqueue_copy_buffer(q, src, dst, nbytes, unsigned(0),
+                              unsigned(0), nothing)
     wait(evt)
     return evt
 end

--- a/src/context.jl
+++ b/src/context.jl
@@ -56,12 +56,12 @@ function Context(devs::Vector{Device};
     if isempty(devs)
         ArgumentError("No devices specified for context")
     end
-    if properties != nothing
+    if properties !== nothing
         ctx_properties = _parse_properties(properties)
     else
         ctx_properties = C_NULL
     end
-    if callback != nothing
+    if callback !== nothing
         ctx_user_data = callback
     else
         ctx_user_data = raise_context_error
@@ -86,12 +86,12 @@ Context(d::Device; properties=nothing, callback=nothing) =
 
 function Context(dev_type::CL_device_type;
                  properties=nothing, callback=nothing)
-    if properties != nothing
+    if properties !== nothing
         ctx_properties = _parse_properties(properties)
     else
         ctx_properties = C_NULL
     end
-    if callback != nothing
+    if callback !== nothing
         ctx_user_data = callback
     else
         ctx_user_data = raise_context_error

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -200,7 +200,7 @@ function enqueue_kernel(q::CmdQueue,
     end
 
     goffset = C_NULL
-    if global_work_offset != nothing
+    if global_work_offset !== nothing
         if length(global_work_offset) > max_work_dim
             throw(ArgumentError("global_work_offset has max dim of $max_work_dim"))
         end
@@ -214,7 +214,7 @@ function enqueue_kernel(q::CmdQueue,
     end
 
     lsize = C_NULL
-    if local_work_size != nothing
+    if local_work_size !== nothing
         if length(local_work_size) > max_work_dim
             throw(ArgumentError("local_work_offset has max dim of $max_work_dim"))
         end
@@ -227,7 +227,7 @@ function enqueue_kernel(q::CmdQueue,
         end
     end
 
-    if wait_on != nothing
+    if wait_on !== nothing
         n_events = cl_uint(length(wait_on))
         wait_event_ids = [evt.id for evt in wait_on]
     else
@@ -246,7 +246,7 @@ function enqueue_task(q::CmdQueue, k::Kernel; wait_for=nothing)
     n_evts  = 0
     evt_ids = C_NULL
     #TODO: this should be split out into its own function
-    if wait_for != nothing
+    if wait_for !== nothing
         if isa(wait_for, Event)
             n_evts = 1
             evt_ids = [wait_for.id]

--- a/src/program.jl
+++ b/src/program.jl
@@ -34,10 +34,10 @@ end
 
 function Program(ctx::Context; source=nothing, binaries=nothing)
     local program_id::CL_program
-    if source != nothing && binaries != nothing
+    if source !== nothing && binaries !== nothing
         throw(ArgumentError("Program be source or binary"))
     end
-    if source != nothing
+    if source !== nothing
         byte_source = [bytestring(source)]
         err_code = Array(CL_int, 1)
         program_id = api.clCreateProgramWithSource(ctx.id, 1, byte_source, C_NULL, err_code)
@@ -46,7 +46,7 @@ function Program(ctx::Context; source=nothing, binaries=nothing)
         end
         return Program(program_id, binary=false)
 
-    elseif binaries != nothing
+    elseif binaries !== nothing
         ndevices = length(binaries)
         device_ids = Array(CL_device_id, ndevices)
         bin_lengths = Array(Csize_t, ndevices)

--- a/test/test_context.jl
+++ b/test/test_context.jl
@@ -15,7 +15,9 @@ facts("OpenCL.Context") do
                 cl.Context(cl.CL_DEVICE_TYPE_CPU)
             catch err
                 @fact typeof(err) --> cl.CLError
-                @fact err.desc --> :CL_INVALID_PLATFORM
+                # CL_DEVICE_NOT_FOUND could be throw for GPU only drivers
+                @fact err.desc --> anyof(:CL_INVALID_PLATFORM,
+                                         :CL_DEVICE_NOT_FOUND)
             end
 
             if platform[:name] == "Portable Computing Language"

--- a/test/test_event.jl
+++ b/test/test_event.jl
@@ -40,17 +40,18 @@ facts("OpenCL.Event") do
                 mkr_evt = cl.enqueue_marker(q)
 
                 @fact usr_evt[:status] --> :submitted
-                @fact cl.cl_event_status(usr_evt[:status]) --> cl.CL_SUBMITTED
-                @fact mkr_evt[:status] --> :queued
-                @fact cl.cl_event_status(mkr_evt[:status]) --> cl.CL_QUEUED
+                @fact mkr_evt[:status] --> anyof(:queued, :submitted)
 
                 cl.complete(usr_evt)
                 @fact usr_evt[:status] --> :complete
-                @fact cl.cl_event_status(usr_evt[:status]) --> cl.CL_COMPLETE
 
                 cl.wait(mkr_evt)
                 @fact mkr_evt[:status] --> :complete
-                @fact cl.cl_event_status(mkr_evt[:status]) --> cl.CL_COMPLETE
+
+                @fact cl.cl_event_status(:running) --> cl.CL_RUNNING
+                @fact cl.cl_event_status(:submitted) --> cl.CL_SUBMITTED
+                @fact cl.cl_event_status(:queued) --> cl.CL_QUEUED
+                @fact cl.cl_event_status(:complete) --> cl.CL_COMPLETE
             end
         end
     end
@@ -87,7 +88,7 @@ facts("OpenCL.Event") do
                 cl.add_callback(mkr_evt, test_callback)
 
                 @fact usr_evt[:status] --> :submitted
-                @fact mkr_evt[:status] --> :queued
+                @fact mkr_evt[:status] --> anyof(:queued, :submitted)
                 @fact callback_called --> false
 
                 cl.complete(usr_evt)

--- a/test/test_program.jl
+++ b/test/test_program.jl
@@ -57,7 +57,11 @@ facts("OpenCL.Program") do
 
             # test build by methods chaining
             @fact prg[:build_status][device] --> cl.CL_BUILD_SUCCESS
-            @fact strip(prg[:build_log][device])--> ""
+            if device[:platform][:name] != "Intel(R) OpenCL"
+                # The intel CPU driver is very verbose on Linux and output
+                # compilation status even without any warnings
+                @fact strip(prg[:build_log][device])--> ""
+            end
         end
     end
 


### PR DESCRIPTION
1. Make the test pass on Intel CPU and NVIDIA GPU drivers on Linux

    * GPU only drivers can return `CL_DEVICE_NOT_FOUND` error when asked for a `CL_DEVICE_TYPE_CPU` context

    * The event returned by `clEnqueueMarker` should in principle return an event of status `CL_QUEUED` but due to the asynchronous nature of OpenCL, it is not forbidden to put it in `CL_SUBMITTED` either. (The Intel CPU driver does this)

    * Disable the compilation output check on Intel CPU driver. Somehow it is very verbose and output info messages even if there's no errors or warnings.

2. Use `===` and `!==` for comparing with `nothing`. Ref https://github.com/JuliaLang/julia/pull/12440

The test suite fully pass (on 0.4-dev at least) with Intel CPU driver 2014_R2 and NVIDIA GPU driver 352.30 now.
