### PR TITLE
Fix deprecation warnings and tests

### DIFF
--- a/src/api/opencl_1.2.0.jl
+++ b/src/api/opencl_1.2.0.jl
@@ -66,7 +66,7 @@
 # @deprecate clEnqueueMarker clEnqueueMarkerWithWaitList
 # @deprecate clEnqueueBarrier clEnqueueMarkerWithWaitList
 # @deprecate clEnqueueWaitForEvents clEnqueueMarkerWithWaitList
-# @deprecate clUnloadCompiler Nothing()
+# @deprecate clUnloadCompiler Void()
 
 # @deprecate clCreateFromGLTexture2D clCreateFromGLTexture
 # @deprecate clCreateFromGLTexture3D clCreateFromGLTexture

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -87,8 +87,8 @@ function Buffer{T}(::Type{T}, ctx::Context, mem_flags::NTuple{2, Symbol}, len::I
 end
 
 # low level Buffer constructor with integer parameter flags
-function Buffer{T}(::Type{T}, ctx::Context, flags::CL_mem_flags, len::Integer=0;
-                   hostbuf::Union(Nothing, Array{T})=nothing)
+@compat function Buffer{T}(::Type{T}, ctx::Context, flags::CL_mem_flags,
+                           len::Integer=0; hostbuf::Union{Void,Array{T}}=nothing)
 
     if (hostbuf !== nothing &&
         (flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR)) == 0)
@@ -100,7 +100,7 @@ function Buffer{T}(::Type{T}, ctx::Context, flags::CL_mem_flags, len::Integer=0;
     end
 
     nbytes = 0
-    retain_buf::Union(Nothing, Array{T}) = nothing
+    retain_buf::Union{Void,Array{T}} = nothing
 
     if hostbuf !== nothing
         if (flags & CL_MEM_USE_HOST_PTR) != 0
@@ -139,13 +139,13 @@ function Buffer{T}(::Type{T}, ctx::Context, flags::CL_mem_flags, len::Integer=0;
 end
 
 # enqueue a read from buffer to hoast array from buffer, return an event
-function enqueue_read_buffer{T}(q::CmdQueue,
-                                buf::Buffer{T},
-                                hostbuf::Array{T},
-                                dev_offset::Csize_t,
-                                wait_for::Union(Nothing, Vector{Event}),
-                                is_blocking::Bool)
-    n_evts  = @compat wait_for === nothing ? UInt(0) : length(wait_for)
+@compat function enqueue_read_buffer{T}(q::CmdQueue,
+                                        buf::Buffer{T},
+                                        hostbuf::Array{T},
+                                        dev_offset::Csize_t,
+                                        wait_for::Union{Void,Vector{Event}},
+                                        is_blocking::Bool)
+    n_evts  = wait_for === nothing ? UInt(0) : length(wait_for)
     evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
     ret_evt = Array(CL_event, 1)
     nbytes  = sizeof(hostbuf)
@@ -157,14 +157,14 @@ function enqueue_read_buffer{T}(q::CmdQueue,
 end
 
 # enqueue a write from host array to buffer, return an event
-function enqueue_write_buffer{T}(q::CmdQueue,
-                                 buf::Buffer{T},
-                                 hostbuf::Array{T},
-                                 byte_count::Csize_t,
-                                 offset::Csize_t,
-                                 wait_for::Union(Nothing, Vector{Event}),
-                                 is_blocking::Bool)
-    n_evts  = @compat wait_for === nothing ? UInt(0) : length(wait_for)
+@compat function enqueue_write_buffer{T}(q::CmdQueue,
+                                         buf::Buffer{T},
+                                         hostbuf::Array{T},
+                                         byte_count::Csize_t,
+                                         offset::Csize_t,
+                                         wait_for::Union{Void,Vector{Event}},
+                                         is_blocking::Bool)
+    n_evts  = wait_for === nothing ? UInt(0) : length(wait_for)
     evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
     ret_evt = Array(CL_event, 1)
     nbytes  = sizeof(hostbuf)
@@ -176,14 +176,14 @@ function enqueue_write_buffer{T}(q::CmdQueue,
 end
 
 # enqueue a copy from one buffer to another, return an event
-function enqueue_copy_buffer{T}(q::CmdQueue,
-                                src::Buffer{T},
-                                dst::Buffer{T},
-                                byte_count::Csize_t,
-                                src_offset::Csize_t,
-                                dst_offset::Csize_t,
-                                wait_for::Union(Nothing, Vector{Event}))
-    n_evts  = @compat wait_for === nothing ? UInt(0) : length(wait_for)
+@compat function enqueue_copy_buffer{T}(q::CmdQueue,
+                                        src::Buffer{T},
+                                        dst::Buffer{T},
+                                        byte_count::Csize_t,
+                                        src_offset::Csize_t,
+                                        dst_offset::Csize_t,
+                                        wait_for::Union{Void,Vector{Event}})
+    n_evts  = wait_for === nothing ? UInt(0) : length(wait_for)
     evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
     ret_evt = Array(CL_event, 1)
     if byte_count < 0
@@ -316,9 +316,10 @@ end
 @ocl_v1_2_only begin
 
     # low level enqueue fill operation, return event
-    function enqueue_fill_buffer{T}(q::CmdQueue, buf::Buffer{T}, pattern::T,
-                                    offset::Csize_t, nbytes::Csize_t,
-                                    wait_for::Union(Vector{Event}, Nothing))
+    @compat function enqueue_fill_buffer{T}(q::CmdQueue, buf::Buffer{T},
+                                            pattern::T, offset::Csize_t,
+                                            nbytes::Csize_t,
+                                            wait_for::Union{Vector{Event},Void})
 
         if wait_for === nothing
             evt_ids = C_NULL

--- a/src/context.jl
+++ b/src/context.jl
@@ -50,9 +50,9 @@ function raise_context_error(error_info, private_info)
 end
 
 
-function Context(devs::Vector{Device};
-                 properties=nothing,
-                 callback::Union(Nothing, Function)=nothing)
+@compat function Context(devs::Vector{Device};
+                         properties=nothing,
+                         callback::Union{Void,Function}=nothing)
     if isempty(devs)
         ArgumentError("No devices specified for context")
     end

--- a/src/device.jl
+++ b/src/device.jl
@@ -61,7 +61,7 @@ let profile(d::Device) = begin
         result = Array(CL_char, size[1])
         @check api.clGetDeviceInfo(d.id, CL_DEVICE_EXTENSIONS, size[1], result, C_NULL)
         bs = bytestring(Compat.unsafe_convert(Ptr{CL_char}, result))
-        return String[string(s) for s in split(bs)]
+        return AbstractString[string(s) for s in split(bs)]
     end
 
     platform(d::Device) = begin

--- a/src/error.jl
+++ b/src/error.jl
@@ -85,7 +85,7 @@ const _cl_error_codes = @compat Dict{Int, Symbol}(
     -1093 => :CL_INVALID_EGL_OBJECT_KHR,
 )
 
-const _cl_err_desc = @compat Dict{Integer, String}(
+const _cl_err_desc = @compat Dict{Integer, AbstractString}(
     CL_INVALID_CONTEXT =>
     "Context is not a valid context.",
 
@@ -164,13 +164,13 @@ const _cl_err_desc = @compat Dict{Integer, String}(
 )
 
 immutable CLMemoryError <: Exception
-    msg::String
+    msg::AbstractString
 end
 
 Base.show(io::IO, err::CLMemoryError) = Base.print(io, "OpenCL.MemObject: $(err.msg)")
 
 immutable OpenCLException <: Exception
-    msg::String
+    msg::AbstractString
 end
 
 Base.show(io::IO, err::OpenCLException) = Base.print(io, "OpenCL Error: $(err.msg)")

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -28,7 +28,7 @@ function release!(k::Kernel)
     end
 end
 
-function Kernel(p::Program, kernel_name::String)
+function Kernel(p::Program, kernel_name::AbstractString)
     for (dev, status) in info(p, :build_status)
         if status != CL_BUILD_SUCCESS
             msg = "OpenCL.Program has to be built before Kernel constructor invoked"
@@ -58,7 +58,7 @@ Base.eltype{T}(l::LocalMem{T}) = T
 Base.sizeof{T}(l::LocalMem{T}) = l.nbytes
 Base.length{T}(l::LocalMem{T}) = @compat Int(l.nbytes ÷ sizeof(T))
 
-function set_arg!(k::Kernel, idx::Integer, arg::Nothing)
+@compat function set_arg!(k::Kernel, idx::Integer, arg::Void)
     @assert idx > 0
     @check api.clSetKernelArg(k.id, cl_uint(idx-1), sizeof(CL_mem), C_NULL)
     return k
@@ -165,9 +165,9 @@ Base.getindex(k::Kernel, args...) = begin
 end
 
 # blocking kernel call that finishes queue
-function call(q::CmdQueue, k::Kernel, global_work_size, local_work_size, args...;
-              global_work_offset=nothing,
-              wait_on::Union(Nothing, Vector{Event})=nothing)
+@compat function call(q::CmdQueue, k::Kernel, global_work_size, local_work_size,
+                      args...; global_work_offset=nothing,
+                      wait_on::Union{Void,Vector{Event}}=nothing)
     set_args!(k, args...)
     evt = enqueue_kernel(q, k,
                          global_work_size,
@@ -182,12 +182,12 @@ function enqueue_kernel(q::CmdQueue, k::Kernel, global_work_size)
     enqueue_kernel(q, k, global_work_size, nothing)
 end
 
-function enqueue_kernel(q::CmdQueue,
-                        k::Kernel,
-                        global_work_size,
-                        local_work_size;
-                        global_work_offset=nothing,
-                        wait_on::Union(Nothing,Vector{Event})=nothing)
+@compat function enqueue_kernel(q::CmdQueue,
+                                k::Kernel,
+                                global_work_size,
+                                local_work_size;
+                                global_work_offset=nothing,
+                                wait_on::Union{Void,Vector{Event}}=nothing)
     device = q[:device]
     max_work_dim = device[:max_work_item_dims]
     work_dim     = length(global_work_size)

--- a/test/test_buffer.jl
+++ b/test/test_buffer.jl
@@ -11,37 +11,37 @@ facts("OpenCL.Buffer") do
             testarray = zeros(Float32, 1000)
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_ALLOC_HOST_PTR | cl.CL_MEM_READ_ONLY,
-                                         length(testarray)) --> anything "no error"
+                                         length(testarray)) --> not(nothing) "no error"
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_ALLOC_HOST_PTR | cl.CL_MEM_WRITE_ONLY,
-                                         length(testarray)) --> anything "no error"
+                                         length(testarray)) --> not(nothing) "no error"
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_ALLOC_HOST_PTR | cl.CL_MEM_READ_WRITE,
-                                         length(testarray)) --> anything "no error"
+                                         length(testarray)) --> not(nothing) "no error"
 
             buf = cl.Buffer(Float32, ctx, cl.CL_MEM_ALLOC_HOST_PTR | cl.CL_MEM_READ_WRITE, length(testarray))
             @fact buf.len --> length(testarray)
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_COPY_HOST_PTR | cl.CL_MEM_READ_ONLY,
-                                         hostbuf=testarray) --> anything "no error"
+                                         hostbuf=testarray) --> not(nothing) "no error"
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_COPY_HOST_PTR | cl.CL_MEM_WRITE_ONLY,
-                                         hostbuf=testarray) --> anything "no error"
+                                         hostbuf=testarray) --> not(nothing) "no error"
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_COPY_HOST_PTR | cl.CL_MEM_READ_WRITE,
-                                         hostbuf=testarray) --> anything "no error"
+                                         hostbuf=testarray) --> not(nothing) "no error"
 
             buf = cl.Buffer(Float32, ctx, cl.CL_MEM_COPY_HOST_PTR | cl.CL_MEM_READ_WRITE, hostbuf=testarray)
             @fact buf.len --> length(testarray)
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_READ_ONLY,
-                                         hostbuf=testarray) --> anything "no error"
+                                         hostbuf=testarray) --> not(nothing) "no error"
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_WRITE_ONLY,
-                                         hostbuf=testarray) --> anything "no error"
+                                         hostbuf=testarray) --> not(nothing) "no error"
 
             @fact cl.Buffer(Float32, ctx, cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_READ_WRITE,
-                                         hostbuf=testarray) --> anything "no error"
+                                         hostbuf=testarray) --> not(nothing) "no error"
 
             buf = cl.Buffer(Float32, ctx, cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_READ_WRITE, hostbuf=testarray)
             @fact buf.len --> length(testarray)
@@ -84,12 +84,12 @@ facts("OpenCL.Buffer") do
                                    ]
                          testarray = zeros(mtype, 100)
                          if mf2 == :copy || mf2 == :use
-                             @fact cl.Buffer(mtype, ctx, (mf1, mf2), hostbuf=testarray) --> anything "no error"
+                             @fact cl.Buffer(mtype, ctx, (mf1, mf2), hostbuf=testarray) --> not(nothing) "no error"
                              buf = cl.Buffer(mtype, ctx, (mf1, mf2), hostbuf=testarray)
                              @fact buf.len --> length(testarray)
                          elseif mf2 == :alloc
                              @fact cl.Buffer(mtype, ctx, (mf1, mf2),
-                                                          length(testarray)) --> anything "no error"
+                                                          length(testarray)) --> not(nothing) "no error"
                              buf = cl.Buffer(mtype, ctx, (mf1, mf2), length(testarray))
                              @fact buf.len --> length(testarray)
                          end
@@ -98,8 +98,8 @@ facts("OpenCL.Buffer") do
              end
 
              test_array = Array(TestStruct, 100)
-             @fact cl.Buffer(TestStruct, ctx, :alloc, length(test_array)) --> anything "no error"
-             @fact cl.Buffer(TestStruct, ctx, :copy, hostbuf=test_array) --> anything "no error"
+             @fact cl.Buffer(TestStruct, ctx, :alloc, length(test_array)) --> not(nothing) "no error"
+             @fact cl.Buffer(TestStruct, ctx, :copy, hostbuf=test_array) --> not(nothing) "no error"
 
              # invalid buffer size should throw error
              @fact_throws cl.Buffer(Float32, ctx, :alloc, +0) "error"

--- a/test/test_cmdqueue.jl
+++ b/test/test_cmdqueue.jl
@@ -6,9 +6,9 @@ facts("OpenCL.CmdQueue") do
         for platform in cl.platforms()
             for device in cl.devices(platform)
                 ctx = cl.Context(device)
-                @fact cl.CmdQueue(ctx) --> anything "no error"
-                @fact cl.CmdQueue(ctx, device) --> anything "no error"
-                @fact cl.CmdQueue(ctx, :profile) --> anything "no error"
+                @fact cl.CmdQueue(ctx) --> not(nothing) "no error"
+                @fact cl.CmdQueue(ctx, device) --> not(nothing) "no error"
+                @fact cl.CmdQueue(ctx, :profile) --> not(nothing) "no error"
                 try
                     cl.CmdQueue(ctx, device, :out_of_order)
                     cl.CmdQueue(ctx, device, (:profile, :out_of_order))

--- a/test/test_context.jl
+++ b/test/test_context.jl
@@ -4,7 +4,7 @@ facts("OpenCL.Context") do
         @fact_throws (cl.Context([])) "error"
         for platform in cl.platforms()
             for device in cl.devices(platform)
-                @fact cl.Context(device) --> anything "no error"
+                @fact cl.Context(device) --> not(nothing) "no error"
             end
         end
     end
@@ -32,8 +32,8 @@ facts("OpenCL.Context") do
                 if !cl.has_device_type(platform, sym_dev_type)
                     continue
                 end
-                @fact cl.Context(sym_dev_type, properties=properties) --> anything
-                @fact cl.Context(cl_dev_type, properties=properties) --> anything
+                @fact cl.Context(sym_dev_type, properties=properties) --> not(nothing)
+                @fact cl.Context(cl_dev_type, properties=properties) --> not(nothing)
                 ctx = cl.Context(cl_dev_type, properties=properties)
                 @fact isempty(cl.properties(ctx)) --> false
                 test_properties = cl.properties(ctx)
@@ -62,7 +62,7 @@ facts("OpenCL.Context") do
     end
 
     context("OpenCL.Context create_some_context") do
-        @fact cl.create_some_context() --> anything "no error"
+        @fact cl.create_some_context() --> not(nothing) "no error"
         @fact typeof(cl.create_some_context()) --> cl.Context
     end
 

--- a/test/test_device.jl
+++ b/test/test_device.jl
@@ -83,7 +83,7 @@ facts("OpenCL.Device") do
                     if k == :extensions
                         @fact isa(d[k], Array) --> true
                         if length(d[k]) > 0
-                            @fact isa(d[k], Array{String, 1}) --> true
+                            @fact isa(d[k], Array{AbstractString, 1}) --> true
                         end
                     elseif k == :platform
                         @fact d[k] --> p

--- a/test/test_device.jl
+++ b/test/test_device.jl
@@ -78,7 +78,7 @@ facts("OpenCL.Device") do
                 @fact isa(d, cl.Device) --> true
                 @fact_throws d[:zjdlkf] "error"
                 for k in device_info_keys
-                    @fact d[k] --> anything "no error"
+                    @fact d[k] --> not(nothing) "no error"
                     @fact d[k] --> cl.info(d, k)
                     if k == :extensions
                         @fact isa(d[k], Array) --> true

--- a/test/test_kernel.jl
+++ b/test/test_kernel.jl
@@ -26,7 +26,7 @@ facts("OpenCL.Kernel") do
             prg = cl.Program(ctx, source=test_source)
             @fact_throws cl.Kernel(prg, "sum") "error"
             cl.build!(prg)
-            @fact cl.Kernel(prg, "sum") --> anything "no error"
+            @fact cl.Kernel(prg, "sum") --> not(nothing) "no error"
         end
     end
 
@@ -63,8 +63,8 @@ facts("OpenCL.Kernel") do
                               (:local_mem_size, cl.CL_KERNEL_LOCAL_MEM_SIZE),
                               (:private_mem_size, cl.CL_KERNEL_PRIVATE_MEM_SIZE),
                               (:prefered_size_multiple, cl.CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE)]
-                @fact cl.work_group_info(k, sf, device) --> anything "no error"
-                @fact cl.work_group_info(k, clf, device) --> anything "no error"
+                @fact cl.work_group_info(k, sf, device) --> not(nothing) "no error"
+                @fact cl.work_group_info(k, clf, device) --> not(nothing) "no error"
                 if sf != :compile_size
                     @fact cl.work_group_info(k, sf, device) --> cl.work_group_info(k, clf, device)
                 end
@@ -102,10 +102,10 @@ facts("OpenCL.Kernel") do
             @fact sizeof(C) --> nbytes
 
             # we use julia's index by one convention
-            @fact cl.set_arg!(k, 1, A)   --> anything "no error"
-            @fact cl.set_arg!(k, 2, B)   --> anything "no error"
-            @fact cl.set_arg!(k, 3, C)   --> anything "no error"
-            @compat @fact cl.set_arg!(k, 4, UInt32(count)) --> anything "no error"
+            @fact cl.set_arg!(k, 1, A)   --> not(nothing) "no error"
+            @fact cl.set_arg!(k, 2, B)   --> not(nothing) "no error"
+            @fact cl.set_arg!(k, 3, C)   --> not(nothing) "no error"
+            @compat @fact cl.set_arg!(k, 4, UInt32(count)) --> not(nothing) "no error"
 
             cl.enqueue_kernel(queue, k, count) |> cl.wait
             r = cl.read(queue, C)

--- a/test/test_memory.jl
+++ b/test/test_memory.jl
@@ -4,7 +4,7 @@ facts("OpenCL.Memory") do
 
         ctx = cl.context(buf)
 
-        @fact ctx --> anything
+        @fact ctx --> not(nothing)
         @fact isequal(ctx, expected) --> true
     end
 

--- a/test/test_program.jl
+++ b/test/test_program.jl
@@ -19,7 +19,7 @@ facts("OpenCL.Program") do
         for device in cl.devices()
             ctx = cl.Context(device)
             prg = cl.Program(ctx, source=test_source)
-            @fact cl.Program(ctx, source=test_source) --> anything "no error"
+            @fact cl.Program(ctx, source=test_source) --> not(nothing) "no error"
         end
     end
     context("OpenCL.Program info") do
@@ -46,7 +46,7 @@ facts("OpenCL.Program") do
         for device in cl.devices()
             ctx = cl.Context(device)
             prg = cl.Program(ctx, source=test_source)
-            @fact cl.build!(prg) --> anything "no error"
+            @fact cl.build!(prg) --> not(nothing) "no error"
 
             # BUILD_SUCCESS undefined in POCL implementation..
             if device[:platform][:name] == "Portable Computing Language"


### PR DESCRIPTION
1. Replace deprecated bindings.
2. Fix test due to https://github.com/JuliaLang/FactCheck.jl/commit/57e4d5b48fabaefa1e7d6b06af400b02c1e05700. (`anything -> not(nothing)`)