### PR TITLE
handle unknown error codes more cleanly

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -180,7 +180,7 @@ immutable CLError <: Exception
     desc::Symbol
 
     function CLError(c::Integer)
-        @compat new(c, _cl_error_codes[Int(c)])
+        @compat new(c, get(_cl_error_codes, Int(c), :CL_UNKNOWN_ERROR_CODE))
     end
 end
 
@@ -188,9 +188,5 @@ Base.show(io::IO, err::CLError) =
         Base.print(io, "CLError(code=$(err.code), $(err.desc))")
 
 function error_description(err::CLError)
-    try
-        _cl_error_descriptions[err.code]
-    catch
-        return "no description for error $(err.desc)"
-    end
+    get(_cl_error_descriptions, err.code, "no description for error $(err.code)")
 end


### PR DESCRIPTION
I ran into a small issue where when trying to use CLBLAS.jl, I wasn't initializing things properly, and CLBLAS returned an error code that is not listed in the `_cl_error_codes` dictionary in `OpenCL.jl/src/error.jl`. This triggered a `KeyError` which was very confusing for a while. Perhaps the constructor of `CLError` should check for unknown error codes, and do something sensible instead of throw a new error, hiding the original source of the problem.