### PR TITLE
silently ignore double free of memory

### DIFF
--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -16,9 +16,6 @@ type Buffer{T} <: CLMemObject
         nbytes = sizeof(T) * len
         buff = new(true, mem_id, len, false, C_NULL)
         finalizer(buff, mem_obj -> begin
-            if !mem_obj.valid
-                throw(CLMemoryError("Attempted to double free OpenCL.Buffer $mem_obj"))
-            end
             release!(mem_obj)
             mem_obj.valid   = false
             mem_obj.mapped  = false

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -19,9 +19,6 @@ Base.sizeof(mem::CLMemObject) = begin
 end
 
 function release!(mem::CLMemObject)
-    if !mem.valid
-        throw(CLMemoryError("attempted to double free mem object $mem"))
-    end
     if mem.id != C_NULL
         @check_release api.clReleaseMemObject(mem.id)
         mem.id = C_NULL


### PR DESCRIPTION
The other thing that tripped me up is the existence of a `release!(buf::Buffer)` function which causes a `CLMemoryError` to be thrown by the `finalizer` if I call it manually, eg to release some memory before the garbage collector gets to it. All the other `release` methods silently become no-ops in case of double free, so doing the same for `CLMemObject` and `Buffer` would make more sense.