### PR TITLE
deprecate release!

### DIFF
--- a/src/OpenCL.jl
+++ b/src/OpenCL.jl
@@ -53,5 +53,5 @@ include("kernel.jl")
 # Util functions
 include("util.jl")
 
-
+@deprecate release! finalize
 end # module

--- a/src/buffer.jl
+++ b/src/buffer.jl
@@ -19,7 +19,7 @@ type Buffer{T} <: CLMemObject
             if !mem_obj.valid
                 throw(CLMemoryError("Attempted to double free OpenCL.Buffer $mem_obj"))
             end
-            release!(mem_obj)
+            _finalize(mem_obj)
             mem_obj.valid   = false
             mem_obj.mapped  = false
             mem_obj.hostbuf = C_NULL

--- a/src/context.jl
+++ b/src/context.jl
@@ -10,16 +10,12 @@ type Context <: CLObject
         ctx = new(ctx_id)
         finalizer(ctx, c -> begin
             retain || _deletecached!(c);
-            release!(c)
+            if ctx.id != C_NULL
+                @check api.clReleaseContext(ctx.id)
+                ctx.id = C_NULL
+            end
         end )
         return ctx
-    end
-end
-
-function release!(ctx::Context)
-    if ctx.id != C_NULL
-        @check api.clReleaseContext(ctx.id)
-        ctx.id = C_NULL
     end
 end
 

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -18,7 +18,7 @@ Base.sizeof(mem::CLMemObject) = begin
     return val[1]
 end
 
-function release!(mem::CLMemObject)
+function _finalize(mem::CLMemObject)
     if !mem.valid
         throw(CLMemoryError("attempted to double free mem object $mem"))
     end

--- a/src/queue.jl
+++ b/src/queue.jl
@@ -10,16 +10,12 @@ type CmdQueue <: CLObject
         q = new(q_id)
         finalizer(q, x -> begin
             retain || _deletecached!(q)
-            release!(x)
+            if q.id != C_NULL
+                @check api.clReleaseCommandQueue(q.id)
+                q.id = C_NULL
+            end
         end )
         return q
-    end
-end
-
-function release!(q::CmdQueue)
-    if q.id != C_NULL
-        @check api.clReleaseCommandQueue(q.id)
-        q.id = C_NULL
     end
 end
 


### PR DESCRIPTION
After the conversation in #78 this deprecates `release!`. It some cases I found it cleaner to not have the finalizer as an anonymous closure, but we should probably decide on one style.