### PR TITLE
Specify julia versions in .travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ os:
   - linux
   - osx
 julia:
-  - release
+  - 0.3
+  - 0.4
   - nightly
 notifications:
   email: false


### PR DESCRIPTION
We should still maintain 0.3 compatibility for a little while.