### PR TITLE
Default queue for context

### DIFF
--- a/src/array.jl
+++ b/src/array.jl
@@ -21,11 +21,12 @@ function CLArray{T,N}(ctx::Context,
 end
 
 function CLArray{T,N}(ctx::Context, hostarray::AbstractArray{T,N};
-                      queue=CmdQueue(ctx), flags=(:rw, :copy))
+                      queue=default_queue(ctx), flags=(:rw, :copy))
     CLArray(ctx, queue, (:rw, :copy), hostarray)
 end
 
-function CLArray{T}(buf::Buffer{T}, sz::Tuple{Vararg{Int}}; queue=CmdQueue(context(buf)))
+function CLArray{T}(buf::Buffer{T}, sz::Tuple{Vararg{Int}};
+                    queue=default_queue(context(buf)))
     ctx = context(buf)
     CLArray(context(buf), queue, buf, sz)
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,8 +1,21 @@
+# cached queues
+const DEFAULT_QUEUES = WeakKeyDict{Context, CmdQueue}()
+
 function create_compute_context()
     ctx    = create_some_context()
     device = first(devices(ctx))
     queue  = CmdQueue(ctx)
+    DEFAULT_QUEUES[ctx] = queue
     return (device, ctx, queue)
+end
+
+function default_queue(ctx::Context)
+    # for some reason WeakKeyDict requires wrapping keys of type Context
+    # into WeakRef(), though other types seem to behave normally
+    if !haskey(DEFAULT_QUEUES, WeakRef(ctx))  
+        DEFAULT_QUEUES[ctx] = CmdQueue(ctx)
+    end
+    return DEFAULT_QUEUES[WeakRef(ctx)]
 end
 
 opencl_version(obj :: CLObject) = api.parse_version(obj[:version])

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -38,9 +38,7 @@ facts("OpenCL.CLArray") do
      end
 
     context("OpenCL.CLArray core functions") do
-        for device in cl.devices()
-            println("MAX_WORK_ITEM_SIZE $(cl.info(device, :max_work_item_size))")
-            
+        for device in cl.devices()            
             ctx = cl.Context(device)
             queue = cl.CmdQueue(ctx)
             A = CLArray(ctx, rand(Float32, 128, 64); queue=queue)
@@ -55,7 +53,7 @@ facts("OpenCL.CLArray") do
             B = cl.zeros(Float32, queue, 64, 128)
             # on Travis in a build for Mac, MAX_WORK_ITEM_SIZE is equal (1024, 1, 1)
             # while transpose's default block_size is 32, so skipping this test for Mac
-            if ENV["TRAVIS"] != "true" || (@linux ? true : false)
+            if get(ENV, "TRAVIS", "false") != "true" || (@linux ? true : false)
                 ev = transpose!(B, A)
                 cl.wait(ev)
                 @fact cl.to_host(A') --> cl.to_host(B)


### PR DESCRIPTION
Quite often we need to work with both - context and queue. Passing both of these variables everywhere looks like an overkill, especially in cases when there's 1:1 correspondence between them. This PR creates a cache for default queues: instead of passing 2 variables or creating new queue from context every time, one can now call `default_queue(ctx)` to get cached value. 

In the PR I also use this capability to provide convenient yet flexible interface for constructing `CLArray`s - if user doesn't pass a queue, the one associated with array's context will be used. 