### PR TITLE
Retrieving context from queue, array functions simplified

### DIFF
--- a/src/queue.jl
+++ b/src/queue.jl
@@ -151,3 +151,5 @@ let
         end
     end
 end
+
+context(queue::CmdQueue) = info(queue, :context)

--- a/test/test_array.jl
+++ b/test/test_array.jl
@@ -8,17 +8,18 @@ facts("OpenCL.CLArray") do
             ctx = cl.Context(device)
             queue = cl.CmdQueue(ctx)
             hostarray = zeros(Float32, 128*64)
-            A = CLArray(ctx, hostarray)
+            A = CLArray(queue, hostarray)
 
-            @fact CLArray(ctx, queue, (:rw, :copy), hostarray) --> not(nothing) "no error"
+            @fact CLArray(queue, (:rw, :copy), hostarray) --> not(nothing) "no error"
 
-            @fact CLArray(ctx, hostarray,
-                          queue=queue, flags=(:rw, :copy)) --> not(nothing) "no error"
+            @fact CLArray(queue, hostarray,
+                          flags=(:rw, :copy)) --> not(nothing) "no error"
 
-            @fact CLArray(ctx, hostarray; queue=queue) --> not(nothing) "no error"
+            @fact CLArray(queue, hostarray) --> not(nothing) "no error"
 
             @fact CLArray(cl.Buffer(Float32, ctx, (:r, :copy), hostbuf=hostarray),
-                          (128, 64); queue=queue) --> not(nothing) "no error"
+                          queue,
+                          (128, 64)) --> not(nothing) "no error"
 
             @fact copy(A) --> A
         end
@@ -38,12 +39,10 @@ facts("OpenCL.CLArray") do
      end
 
     context("OpenCL.CLArray core functions") do
-        for device in cl.devices()
-            println("MAX_WORK_ITEM_SIZE $(cl.info(device, :max_work_item_size))")
-            
+        for device in cl.devices()            
             ctx = cl.Context(device)
             queue = cl.CmdQueue(ctx)
-            A = CLArray(ctx, rand(Float32, 128, 64); queue=queue)
+            A = CLArray(queue, rand(Float32, 128, 64))
             @fact size(A) --> (128, 64)
             @fact ndims(A) --> 2
             @fact length(A) --> 128*64
@@ -51,11 +50,11 @@ facts("OpenCL.CLArray") do
             B = reshape(A, 128*64)
             @fact reshape(B, 128, 64) --> A
             # transpose
-            X = CLArray(ctx, rand(Float32, 32, 32); queue=queue)
+            X = CLArray(queue, rand(Float32, 32, 32))
             B = cl.zeros(Float32, queue, 64, 128)
             # on Travis in a build for Mac, MAX_WORK_ITEM_SIZE is equal (1024, 1, 1)
             # while transpose's default block_size is 32, so skipping this test for Mac
-            if ENV["TRAVIS"] != "true" || (@linux ? true : false)
+            if get(ENV, "TRAVIS", "false") != "true" || (@linux ? true : false)
                 ev = transpose!(B, A)
                 cl.wait(ev)
                 @fact cl.to_host(A') --> cl.to_host(B)


### PR DESCRIPTION
Since it's possible to retrieve `Context` from `CmdQueue`, there's no need to pass them both everywhere. This PR simplifies array implementation according to this possibility. 