### PR TITLE
Fixes travis by enabling restricted and updates repository

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,8 +13,9 @@ notifications:
 
 before_install:
   - if [ $TRAVIS_OS_NAME = "linux" ]; then
+      sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-updates main restricted";
       sudo apt-get update -qq -y;
-      sudo apt-get install -qq fglrx opencl-headers;
+      sudo apt-get install -qq fglrx opencl-headers git;
     fi;
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 


### PR DESCRIPTION
fglrx is only available in restricted and we probably want a more up to date version.

I am hoping that at some point we can switch to the docker infrastructure, but that is depending on:

https://github.com/travis-ci/apt-package-whitelist/pull/750