### PR TITLE
Make use of the new travis docker infrastructure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: julia
+sudo: false
 
 os:
   - linux
@@ -13,9 +14,19 @@ notifications:
 
 before_install:
   - if [ $TRAVIS_OS_NAME = "linux" ]; then
-      sudo add-apt-repository "deb http://archive.ubuntu.com/ubuntu $(lsb_release -sc)-updates main restricted";
-      sudo apt-get update -qq -y;
-      sudo apt-get install -qq fglrx opencl-headers git;
+      git clone https://gist.github.com/1faa40c2df51e3a9ee55.git amd;
+      cd amd;
+      bash amd_sdk.sh;
+      tar -xjf AMD-SDK.tar.bz2;
+      AMDAPPSDK=${HOME}/AMDAPPSDK;
+      export OPENCL_VENDOR_PATH=${AMDAPPSDK}/etc/OpenCL/vendors;
+      mkdir -p ${OPENCL_VENDOR_PATH};
+      sh AMD-APP-SDK*.sh --tar -xf -C ${AMDAPPSDK};
+      echo libamdocl64.so > ${OPENCL_VENDOR_PATH}/amdocl64.icd;
+      export LD_LIBRARY_PATH=${AMDAPPSDK}/lib/x86_64:${LD_LIBRARY_PATH};
+      cd ..;
+      chmod +x ${AMDAPPSDK}/bin/x86_64/clinfo;
+      ${AMDAPPSDK}/bin/x86_64/clinfo;
     fi;
   - if [[ -a .git/shallow ]]; then git fetch --unshallow; fi
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -2,17 +2,10 @@ module api
 
 include("types.jl")
 
-@osx_only begin
-    const libopencl = "/System/Library/Frameworks/OpenCL.framework/OpenCL"
-end
+paths = @osx? ["/System/Library/Frameworks/OpenCL.framework"] : ByteString[]
 
-@linux_only begin
-    const libopencl = "libOpenCL"
-end
-
-@windows_only begin
-    const libopencl = "OpenCL"
-end
+const libopencl = Libdl.find_library(["libOpenCL", "OpenCL"], paths)
+@assert libopencl != ""
 
 function _ocl_func(func, ret_type, arg_types)
     local args_in = Symbol[symbol("arg$i::$T")

--- a/src/event.jl
+++ b/src/event.jl
@@ -26,7 +26,7 @@ type NannyEvent <: CLEvent
         end
         nanny_evt = new(evt_id, obj)
         finalizer(nanny_evt, x -> begin
-            wait(x)
+            x.id != C_NULL && wait(x)
             x.obj = nothing
             _finalize(x)
         end)
@@ -190,7 +190,7 @@ function enqueue_wait_for_events{T<:CLEvent}(q::CmdQueue, wait_for::Vector{T})
     n_wait_events = cl_uint(length(wait_for))
     wait_evt_ids = [evt.id for evt in wait_for]
     @check api.clEnqueueWaitForEvents(q.id, n_wait_events,
-                                      isempty(wait_evt_ids) ? C_NULL : wait_evt_ids)
+                                      isempty(wait_evt_ids) ? C_NULL : pointer(wait_evt_ids))
 end
 
 function enqueue_wait_for_events(q::CmdQueue, wait_for::CLEvent)

--- a/test/test_platform.jl
+++ b/test/test_platform.jl
@@ -9,7 +9,7 @@ facts("OpenCL.Platform") do
                 @fact p[k] == cl.info(p, k) --> true
             end
             v = cl.opencl_version(p)
-            @fact v.major --> 1
+            @fact 1 <= v.major <= 2  --> true
             @fact 0 <= v.minor <= 2  --> true
          end
      end


### PR DESCRIPTION
So the aim of this is to enable the docker infrastructure for travis testing. The problem is that one has to install a working OpenCL implementation manually.

I got the AMD APP SDK working, which is quite nice because we now can test OpenCL 2.0 on travis. The only show stopper right now is a seqfault in waitforevents

https://travis-ci.org/JuliaGPU/OpenCL.jl/jobs/102318248

@dfdx If I can fix the seqfault this should be quite nice, additionally we could think about installing pocl and testing our code against two implementations. I moved back to AMD because one can't install the Intel one without root rights.