### PR TITLE
more types for setarg

### DIFF
--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -79,7 +79,7 @@ function set_arg!(k::Kernel, idx::Integer, arg::CLMemObject)
 end
 
 function set_arg!(k::Kernel, idx::Integer, arg::LocalMem)
-    @assert idx > 0
+    @assert idx > 0 "Kernel idx must be bigger 0"
     @check api.clSetKernelArg(k.id, cl_uint(idx-1), arg.nbytes, C_NULL)
     return k
 end

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -73,7 +73,7 @@ end
 
 function set_arg!(k::Kernel, idx::Integer, arg::CLMemObject)
     @assert idx > 0
-    arg_boxed = Ref(arg.id)
+    arg_boxed = Ref{typeof(arg.id)}(arg.id)
     @check api.clSetKernelArg(k.id, cl_uint(idx-1), sizeof(CL_mem), arg_boxed)
     return k
 end
@@ -90,7 +90,7 @@ function set_arg!{T}(k::Kernel, idx::Integer, arg::T)
     if !isbits(T) # TODO add more thorough mem layout checks and the clang stuff
         error("Only isbits types allowed. Found: $T")
     end
-    boxed_arg = Ref(arg)
+    boxed_arg = Ref{T}(arg)
     @check api.clSetKernelArg(k.id, cl_uint(idx - 1), sizeof(T), boxed_arg)
     return k
 end


### PR DESCRIPTION
This allows more and is potentially more unsafe. 
We could warn when an unknown type is used, or we could read through julia's and opencl padding and mem layout and see if we can come up with better rules!