### PR TITLE
Fixing printing of error description text.

### DIFF
--- a/src/error.jl
+++ b/src/error.jl
@@ -188,5 +188,5 @@ Base.show(io::IO, err::CLError) =
         Base.print(io, "CLError(code=$(err.code), $(err.desc))")
 
 function error_description(err::CLError)
-    get(_cl_error_descriptions, err.code, "no description for error $(err.code)")
+    get(_cl_err_desc, err.code, "no description for error $(err.code)")
 end


### PR DESCRIPTION
Minor typo in error.jl _cl_err_desc was referred to as _cl_err_descriptions in error_description( ).

I've checked that there is no other reference to _cl_err_descriptions in the repo. But I'm not sure what testing standards you normally operate. This is just a quick fix to an apparently obvious bug.