### PR TITLE
try to print error better

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -89,16 +89,23 @@ immutable _CtxErr
     cb :: Csize_t
 end
 
-function ctx_notify_err(err_info::Ptr{Cchar}, priv_info::Ptr{Void},
-                        cb::Csize_t, payload::Ptr{Void})
-    ptr = convert(Ptr{_CtxErr}, payload)
-    handle = unsafe_load(ptr).handle
+const io_lock = ReentrantLock()
+function log_error(message...)
+    @async begin
+        lock(STDERR)
+        lock(io_lock)
+        print(STDERR, string(message..., "\n"))
+        unlock(io_lock)
+        unlock(STDERR)
+    end
+end
 
-    val = _CtxErr(handle, err_info, priv_info, cb)
-    unsafe_store!(ptr, val)
-
-    ccall(:uv_async_send, Void, (Ptr{Void},), handle)
-    nothing
+function ctx_notify_err(
+        err_info::Ptr{Cchar}, priv_info::Ptr{Void},
+        cb::Csize_t, payload::Ptr{Void}
+    )
+    log_error("OpenCL Error: | ", unsafe_string(err_info), " |")
+    return
 end
 
 
@@ -128,31 +135,15 @@ function Context(devs::Vector{Device};
         device_ids[i] = d.id
     end
 
-    cb = Base.AsyncCondition()
-    ctx_user_data = Ref(_CtxErr(Base.unsafe_convert(Ptr{Void}, cb), 0, 0, 0))
-
     err_code = Ref{CL_int}()
-    ctx_id = api.clCreateContext(ctx_properties, n_devices, device_ids,
-                                 ctx_callback_ptr(), ctx_user_data, err_code)
+    ctx_id = api.clCreateContext(
+        ctx_properties, n_devices, device_ids,
+        ctx_callback_ptr(), C_NULL, err_code
+    )
     if err_code[] != CL_SUCCESS
         throw(CLError(err_code[]))
     end
-
     true_callback = callback == nothing ? raise_context_error : callback :: Function
-
-    @async begin
-        try
-            Base.wait(cb)
-            err = ctx_user_data[]
-            error_info = unsafe_string(err.err_info)
-            true_callback(error_info, "")
-        catch
-            rethrow()
-        finally
-            Base.close(cb)
-        end
-    end
-
     return Context(ctx_id)
 end
 

--- a/test/test_context.jl
+++ b/test/test_context.jl
@@ -1,5 +1,5 @@
 
-function test_callback(arg1, arg2, arg3)
+function context_test_callback(arg1, arg2, arg3)
     # We're not really testing it because, nvidia doesn't seem to care about this functionality:
     # https://devtalk.nvidia.com/default/topic/497433/context-callback-never-called/
     OpenCL.cl.log_error("Callback works")
@@ -8,12 +8,12 @@ end
 function create_context_error(ctx)
     empty_kernel = "
     __kernel void test() {
-        return;
+        int c = 1 + 1;
     };"
-    p = cl.Program(ctx, source = empty_kernel) |> cl.build!
-    k = cl.Kernel(p, "test")
-    q = cl.CmdQueue(ctx)
     try
+        p = cl.Program(ctx, source = empty_kernel) |> cl.build!
+        k = cl.Kernel(p, "test")
+        q = cl.CmdQueue(ctx)
         q(k, 1, 10000000)
     end
 end
@@ -42,7 +42,7 @@ end
                 # NVIDIA 381.22
                 #@test !cl.is_ctx_id_alive(ctx_id)
                 @testset "Context callback" begin
-                    ctx = cl.Context(device, callback = test_callback)
+                    ctx = cl.Context(device, callback = context_test_callback)
                     create_context_error(ctx)
                 end
             end

--- a/test/test_context.jl
+++ b/test/test_context.jl
@@ -1,3 +1,24 @@
+
+function test_callback(arg1, arg2, arg3)
+    # We're not really testing it because, nvidia doesn't seem to care about this functionality:
+    # https://devtalk.nvidia.com/default/topic/497433/context-callback-never-called/
+    OpenCL.cl.log_error("Callback works")
+    return
+end
+function create_context_error(ctx)
+    empty_kernel = "
+    __kernel void test() {
+        return;
+    };"
+    p = cl.Program(ctx, source = empty_kernel) |> cl.build!
+    k = cl.Kernel(p, "test")
+    q = cl.CmdQueue(ctx)
+    try
+        q(k, 1, 10000000)
+    end
+end
+
+
 @testset "OpenCL.Context" begin
     @testset "OpenCL.Context constructor" begin
         @test_throws MethodError (cl.Context([]))
@@ -20,7 +41,10 @@
                 # jeez, this segfaults... WHY? I suspect a driver bug for refcount == 0?
                 # NVIDIA 381.22
                 #@test !cl.is_ctx_id_alive(ctx_id)
-
+                @testset "Context callback" begin
+                    ctx = cl.Context(device, callback = test_callback)
+                    create_context_error(ctx)
+                end
             end
         end
     end


### PR DESCRIPTION
One problem this fixes is, that the callback also get's called for warnings. 
In the previous version, this would generate a fatal error.
One problem it's introducing: I disregard user callbacks ;)
Do we want to fix that problem, or is no one using that feature anyways?
We probably should add a deprecation in that case.