### PR TITLE
allow more tests for new version of POCL

### DIFF
--- a/test/REQUIRE
+++ b/test/REQUIRE
@@ -1,0 +1,1 @@
+VersionParsing

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -1,7 +1,18 @@
 module TestOpenCL
-using Base.Test
+using Base.Test, VersionParsing
 
 using OpenCL
+
+function is_old_pocl(platform::cl.Platform)
+    res = false
+    if platform[:name] == "Portable Computing Language"
+        m = match(r"pocl \d+.\d+", platform[:version])
+        if !(m != nothing && vparse(m.match) >= v"1.2")
+            res = true
+        end
+    end
+    res
+end
 
 @testset "layout" begin
     x = ((10f0, 1f0, 2f0), (10f0, 1f0, 2f0), (10f0, 1f0, 2f0))

--- a/test/test_behaviour.jl
+++ b/test/test_behaviour.jl
@@ -18,8 +18,8 @@ info(
     hello_world_str = "hello world"
 
     for device in cl.devices()
-        if device[:platform][:name] == "Portable Computing Language"
-            warn("Skipping OpenCL.Kernel mem/workgroup size for Portable Computing Language Platform")
+        if is_old_pocl(device[:platform])
+            warn("Skipping OpenCL Hello World Test for Portable Computing Language Platform")
             continue
         end
 
@@ -241,8 +241,8 @@ let test_struct = "
 @testset "OpenCL Struct Buffer Test" begin
     for device in cl.devices()
 
-        if device[:platform][:name] == "Portable Computing Language"
-            warn("Skipping OpenCL Struct Buffer Test for Portable Computing Language Platform")
+        if is_old_pocl(device[:platform])
+            warn("Skipping OpenCL Struct Buffer Test for old Portable Computing Language Platform")
             continue
         end
 
@@ -302,8 +302,8 @@ let test_mutable_pointerfree = "
 @testset "OpenCL Struct Buffer Test" begin
     for device in cl.devices()
 
-        if device[:platform][:name] == "Portable Computing Language"
-            warn("Skipping OpenCL Struct Buffer Test for Portable Computing Language Platform")
+        if is_old_pocl(device[:platform])
+            warn("Skipping OpenCL Struct Buffer Test for old Portable Computing Language Platform")
             continue
         end
 

--- a/test/test_buffer.jl
+++ b/test/test_buffer.jl
@@ -118,9 +118,9 @@ end
 
      @testset "OpenCL.Buffer fill" begin
         for device in cl.devices()
-             if contains(device[:platform][:name], "Portable")
-                 # the pocl platform claims to implement v1.2 of the spec, but does not
-                 warn("Skipping test OpenCL.Buffer fill for POCL Platform")
+             if is_old_pocl(device[:platform])
+                 # the old pocl platform claims to implement v1.2 of the spec, but does not
+                 warn("Skipping test OpenCL.Buffer fill for old POCL Platform")
                  continue
              end
              ctx = cl.Context(device)

--- a/test/test_context.jl
+++ b/test/test_context.jl
@@ -60,10 +60,9 @@ end
                                          :CL_DEVICE_NOT_FOUND)
             end
 
-            if platform[:name] == "Portable Computing Language"
+            if is_old_pocl(platform)
                 warn("Skipping OpenCL.Context platform properties for " *
-                     "Portable Computing Language Platform")
-                continue
+                     "old Portable Computing Language Platform")
             end
 
             properties = [(cl.CL_CONTEXT_PLATFORM, platform)]

--- a/test/test_device.jl
+++ b/test/test_device.jl
@@ -66,10 +66,9 @@
                 :max_image3d_shape,
             ]
         for p in cl.platforms()
-            if contains(p[:name], "Portable")
-                msg = "Skipping Device Info tests for Portable Computing Language Platform "
-                warn(msg)
-                continue
+            if is_old_pocl(p) 
+                warn("Skipping Device Info tests for " *
+                     "old Portable Computing Language Platform")
             end
             @test isa(p, cl.Platform)
             @test_throws ArgumentError p[:zjdlkf]

--- a/test/test_event.jl
+++ b/test/test_event.jl
@@ -1,10 +1,9 @@
 @testset "OpenCL.Event" begin
     @testset "OpenCL.Event status" begin
         for platform in cl.platforms()
-            if contains(platform[:name], "Portable")
-                msg = "$(platform[:name]) does not implement User Events"
-                warn(msg)
-                continue
+            if is_old_pocl(platform)
+                warn("Old Portable Computing Language Platform" *
+                     "does not implement User Events")
             end
 
             for device in cl.devices(platform)

--- a/test/test_kernel.jl
+++ b/test/test_kernel.jl
@@ -23,7 +23,7 @@ end
 
     @testset "OpenCL.Kernel constructor" begin
         for device in cl.devices()
-            if device[:platform][:name] == "Portable Computing Language"
+            if is_old_pocl(device[:platform])
                 warn("Skipping OpenCL.Kernel constructor for " *
                      "Portable Computing Language Platform")
                 continue
@@ -38,7 +38,7 @@ end
 
     @testset "OpenCL.Kernel info" begin
         for device in cl.devices()
-            if device[:platform][:name] == "Portable Computing Language"
+            if is_old_pocl(device[:platform])
                 warn("Skipping OpenCL.Kernel info for Portable Computing Language Platform")
                 continue
             end
@@ -56,8 +56,9 @@ end
 
     @testset "OpenCL.Kernel mem/workgroup size" begin
         for device in cl.devices()
-            if device[:platform][:name] == "Portable Computing Language"
-                warn("Skipping OpenCL.Kernel mem/workgroup size for Portable Computing Language Platform")
+            if is_old_pocl(device[:platform])
+                warn("Skipping OpenCL.Kernel mem/workgroup size for " *
+                     "old Portable Computing Language Platform")
                 continue
             end
             ctx = cl.Context(device)
@@ -82,8 +83,9 @@ end
     @testset "OpenCL.Kernel set_arg!/set_args!" begin
          for device in cl.devices()
 
-            if device[:platform][:name] == "Portable Computing Language"
-                warn("Skipping OpenCL.Kernel mem/workgroup size for Portable Computing Language Platform")
+            if is_old_pocl(device[:platform])
+                warn("Skipping OpenCL.Kernel set_arg!/set_args! for " *
+                     "old Portable Computing Language Platform")
                 continue
             end
 
@@ -142,8 +144,9 @@ end
 
     @testset "OpenCL.Kernel enqueue_kernel" begin
         for device in cl.devices()
-            if device[:platform][:name] == "Portable Computing Language"
-                warn("Skipping OpenCL.Kernel mem/workgroup size for Portable Computing Language Platform")
+            if is_old_pocl(device[:platform])
+                warn("Skipping OpenCL.Kernel enqueue_kernel for " *
+                     "old Portable Computing Language Platform")
                 continue
             end
 
@@ -241,9 +244,9 @@ end
     "
 
     for device in cl.devices()
-        if device[:platform][:name] == "Portable Computing Language"
+        if is_old_pocl(device[:platform])
             warn("Skipping OpenCL.Kernel constructor for " *
-                 "Portable Computing Language Platform")
+                 "old Portable Computing Language Platform")
             continue
         end
         ctx = cl.Context(device)

--- a/test/test_program.jl
+++ b/test/test_program.jl
@@ -37,7 +37,12 @@
             @test prg[:source] == test_source
 
             @test prg[:reference_count] > 0
-            @test isempty(strip(prg[:build_log][device]))
+            if device[:platform][:name] == "Portable Computing Language"
+                warn("Skipping OpenCL.Program info test for " *
+                     "Portable Computing Language")
+            else
+                @test isempty(strip(prg[:build_log][device]))
+            end
          end
     end
 
@@ -48,8 +53,8 @@
             @test cl.build!(prg) != nothing
 
             # BUILD_SUCCESS undefined in POCL implementation..
-            if device[:platform][:name] == "Portable Computing Language"
-                warn("Skipping OpenCL.Program build for Portable Computing Language Platform")
+            if is_old_pocl(device[:platform])
+                warn("Skipping OpenCL.Program build for old Portable Computing Language Platform")
                 continue
             end
             @test prg[:build_status][device] == cl.CL_BUILD_SUCCESS
@@ -83,7 +88,12 @@
             @test binaries[device] != nothing
             @test length(binaries[device]) > 0
             prg2 = cl.Program(ctx, binaries=binaries)
-            @test prg2[:binaries] == binaries
+            if device[:platform][:name] == "Portable Computing Language"
+                warn("Skipping OpenCL.Program binaries test for " *
+                     "Portable Computing Language")
+            else
+                @test prg2[:binaries] == binaries
+            end
             try
                 prg2[:source]
                 error("should not happen")


### PR DESCRIPTION
Using a recent version of POCL, some of the tests that have been skipped pass. Locally, all tests pass for me with the following version of POCL.
```
OpenCL$ clinfo
Number of platforms                               1
  Platform Name                                   Portable Computing Language
  Platform Vendor                                 The pocl project
  Platform Version                                OpenCL 1.2 pocl 1.2-pre/master-0-g0e6fc99f Release, LLVM 3.8.1, SLEEF, POCL_DEBUG
  Platform Profile                                FULL_PROFILE
  Platform Extensions                             cl_khr_icd
  Platform Extensions function suffix             POCL

  Platform Name                                   Portable Computing Language
Number of devices                                 1
  Device Name                                     pthread-Intel(R) Core(TM) i5-4590S CPU @ 3.00GHz
  Device Vendor                                   GenuineIntel
  Device Vendor ID                                0x8086
  Device Version                                  OpenCL 1.2 pocl HSTR: pthread-x86_64-pc-linux-gnu-haswell
  Driver Version                                  1.2-pre/master-0-g0e6fc99f
  Device OpenCL C Version                         OpenCL C 1.2 pocl
  Device Type                                     CPU
  Device Profile                                  FULL_PROFILE
  Max compute units                               4
  Max clock frequency                             3700MHz
  Device Partition                                (core)
    Max number of sub-devices                     4
    Supported partition types                     equally, by counts
  Max work item dimensions                        3
  Max work item sizes                             4096x4096x4096
  Max work group size                             4096
  Preferred work group size multiple              8
  Preferred / native vector sizes                 
    char                                                16 / 16      
    short                                               16 / 16      
    int                                                  8 / 8       
    long                                                 4 / 4       
    half                                                 0 / 0        (n/a)
    float                                                8 / 8       
    double                                               4 / 4        (cl_khr_fp64)
  Half-precision Floating-point support           (n/a)
  Single-precision Floating-point support         (core)
    Denormals                                     Yes
    Infinity and NANs                             Yes
    Round to nearest                              Yes
    Round to zero                                 Yes
    Round to infinity                             Yes
    IEEE754-2008 fused multiply-add               Yes
    Support is emulated in software               No
    Correctly-rounded divide and sqrt operations  Yes
  Double-precision Floating-point support         (cl_khr_fp64)
    Denormals                                     Yes
    Infinity and NANs                             Yes
    Round to nearest                              Yes
    Round to zero                                 Yes
    Round to infinity                             Yes
    IEEE754-2008 fused multiply-add               Yes
    Support is emulated in software               No
    Correctly-rounded divide and sqrt operations  Yes
  Address bits                                    64, Little-Endian
  Global memory size                              6132338688 (5.711GiB)
  Error Correction support                        No
  Max memory allocation                           2147483648 (2GiB)
  Unified memory for Host and Device              Yes
  Minimum alignment for any data type             128 bytes
  Alignment of base address                       1024 bits (128 bytes)
  Global Memory cache type                        Read/Write
  Global Memory cache size                        6291456
  Global Memory cache line                        64 bytes
  Image support                                   Yes
    Max number of samplers per kernel             16
    Max size for 1D images from buffer            134217728 pixels
    Max 1D or 2D image array size                 2048 images
    Max 2D image size                             8192x8192 pixels
    Max 3D image size                             2048x2048x2048 pixels
    Max number of read image args                 128
    Max number of write image args                128
  Local memory type                               Global
  Local memory size                               4194304 (4MiB)
  Max constant buffer size                        4194304 (4MiB)
  Max number of constant args                     8
  Max size of kernel argument                     1024
  Queue properties                                
    Out-of-order execution                        No
    Profiling                                     Yes
  Prefer user sync for interop                    Yes
  Profiling timer resolution                      1ns
  Execution capabilities                          
    Run OpenCL kernels                            Yes
    Run native kernels                            Yes
  printf() buffer size                            16777216 (16MiB)
  Built-in kernels                                
  Device Available                                Yes
  Compiler Available                              Yes
  Linker Available                                Yes
  Device Extensions                               cl_khr_byte_addressable_store cl_khr_global_int32_base_atomics cl_khr_global_int32_extended_atomics cl_khr_local_int32_base_atomics cl_khr_local_int32_extended_atomics cl_khr_3d_image_writes cl_khr_fp64 cl_khr_int64_base_atomics cl_khr_int64_extended_atomics cl_khr_fp64

NULL platform behavior
  clGetPlatformInfo(NULL, CL_PLATFORM_NAME, ...)  Portable Computing Language
  clGetDeviceIDs(NULL, CL_DEVICE_TYPE_ALL, ...)   Success [POCL]
  clCreateContext(NULL, ...) [default]            Success [POCL]
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CPU)  Success (1)
    Platform Name                                 Portable Computing Language
    Device Name                                   pthread-Intel(R) Core(TM) i5-4590S CPU @ 3.00GHz
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_GPU)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ACCELERATOR)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_CUSTOM)  No devices found in platform
  clCreateContextFromType(NULL, CL_DEVICE_TYPE_ALL)  Success (1)
    Platform Name                                 Portable Computing Language
    Device Name                                   pthread-Intel(R) Core(TM) i5-4590S CPU @ 3.00GHz

ICD loader properties
  ICD loader Name                                 OpenCL ICD Loader
  ICD loader Vendor                               OCL Icd free software
  ICD loader Version                              2.2.11
  ICD loader Profile                              OpenCL 2.1
```