### PR TITLE
Additional fixes for Julia 1.0 support as well as failures on OpenCL 1.1

### DIFF
--- a/src/context.jl
+++ b/src/context.jl
@@ -91,11 +91,11 @@ end
 const io_lock = ReentrantLock()
 function log_error(message...)
     @async begin
-        lock(STDERR)
+        lock(stderr)
         lock(io_lock)
-        print(STDERR, string(message..., "\n"))
+        print(stderr, string(message..., "\n"))
         unlock(io_lock)
-        unlock(STDERR)
+        unlock(stderr)
     end
 end
 

--- a/src/kernel.jl
+++ b/src/kernel.jl
@@ -406,11 +406,13 @@ function info(k::Kernel, kinfo::Symbol)
         return Program(ret[], retain=true)
     end
 
+    # Only supported for version 1.2 and above
     attributes(k::Kernel) = begin
         size = Ref{Csize_t}()
-        api.clGetKernelInfo(k.id, CL_KERNEL_ATTRIBUTES,
-                            0, C_NULL, size)
-        if size[] <= 1
+        rcode = api.clGetKernelInfo(k.id, CL_KERNEL_ATTRIBUTES,
+                                    0, C_NULL, size)
+        # Version 1.1 mostly MESA drivers will pass through the below condition
+        if rcode == CL_INVALID_VALUE || size[] <= 1
             return ""
         end
         result = Vector{CL_char}(undef, size[])

--- a/src/platform.jl
+++ b/src/platform.jl
@@ -60,33 +60,6 @@ function info(p::Platform, pinfo::CL_platform_info)
     return CLString(result)
 end
 
-
-let info_map = Dict{Symbol, CL_platform_info}(
-        :profile => CL_PLATFORM_PROFILE,
-        :version => CL_PLATFORM_VERSION,
-        :name    => CL_PLATFORM_NAME,
-        :vendor  => CL_PLATFORM_VENDOR,
-        :extensions => CL_PLATFORM_EXTENSIONS
-    )
-    global info
-    function info(p::Platform, pinfo::Symbol)
-        try
-            cl_info = info_map[pinfo]
-            if pinfo == :extensions
-                split(info(p, cl_info))
-            else
-                info(p, cl_info)
-            end
-        catch err
-            if isa(err, KeyError)
-                throw(ArgumentError("OpenCL.Platform has no info for: $pinfo"))
-            else
-                throw(err)
-            end
-        end
-    end
-end
-
 function devices(p::Platform, dtype::CL_device_type)
     try
         ndevices = Ref{CL_uint}()

--- a/src/program.jl
+++ b/src/program.jl
@@ -95,11 +95,11 @@ function build!(p::Program; options = "", raise = true)
     end
     for (dev, status) in cl.info(p, :build_status)
         if status == cl.CL_BUILD_ERROR
-            println(STDERR, "Couldn't compile kernel: ")
+            println(stderr, "Couldn't compile kernel: ")
             source = info(p, :source)
-            print_with_linenumbers(source, "    ", STDERR)
-            println(STDERR, "With following build error:")
-            println(STDERR, cl.info(p, :build_log)[dev])
+            print_with_linenumbers(source, "    ", stderr)
+            println(stderr, "With following build error:")
+            println(stderr, cl.info(p, :build_log)[dev])
             raise && @check err # throw the build error when raise!
         end
     end


### PR DESCRIPTION
Mostly a few fixes missed out in Julia 1.0 related fixes. Kernel attribute query which does not go well on OpenCL 1.1. 

@SimonDanisch do you already have these changes in your radar? I see you already have a long WIP. I am seeing some issues with object layouts and it fails on my `AMD Radeon (TM) R7 M360 (ICELAND / DRM 3.23.0 / 4.15.0-36-generic, LLVM 6.0.0)`. 