### PR TITLE
use VersionParsing

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.8.1"
 Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
+VersionParsing = "81def892-9a0e-5fdd-b105-ffc91e053289"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/src/api.jl
+++ b/src/api.jl
@@ -1,5 +1,7 @@
 module api
 
+import VersionParsing
+
 include("types.jl")
 
 const paths = Sys.isapple() ? String["/System/Library/Frameworks/OpenCL.framework"] : String[]
@@ -41,13 +43,6 @@ include("api/opencl_1.1.0.jl")
 include("api/opencl_1.2.0.jl")
 include("api/opencl_2.0.0.jl")
 
-function parse_version(version_string)
-    mg = match(r"^OpenCL ([0-9]+)\.([0-9]+) .*$", version_string)
-    if mg === nothing
-        error("Non conforming version string: $(ver)")
-    end
-    return VersionNumber(parse(Int, mg.captures[1]),
-                                 parse(Int, mg.captures[2]))
-end
+parse_version(version_string) = VersionParsing.vparse(version_string)
 
 end


### PR DESCRIPTION
I noticed that you were doing your own version-number parsing, and thought you might want to use the VersionParsing parsing package instead for more flexibility.