### PR TITLE
Add OpenCL_jll dependence

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,8 +3,8 @@ uuid = "08131aa3-fb12-5dee-8b74-c09406e224a2"
 version = "0.8.1"
 
 [deps]
-Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
+OpenCL_jll = "6cb37087-e8b6-5417-8430-1f242f1e46e4"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
 [extras]

--- a/Project.toml
+++ b/Project.toml
@@ -7,6 +7,9 @@ LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OpenCL_jll = "6cb37087-e8b6-5417-8430-1f242f1e46e4"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"
 
+[compat]
+OpenCL_jll = "2022.9.23"
+
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 

--- a/src/api.jl
+++ b/src/api.jl
@@ -2,11 +2,9 @@ module api
 
 include("types.jl")
 
-const paths = Sys.isapple() ? String["/System/Library/Frameworks/OpenCL.framework"] : String[]
+import OpenCL_jll
 
-import Libdl
-
-const libopencl = Libdl.find_library(["libOpenCL", "OpenCL"], paths)
+const libopencl = OpenCL_jll.libopencl
 
 function _ocl_func(func, ret_type, arg_types)
     local args_in = Symbol[Symbol("arg$i")


### PR DESCRIPTION
This PR aims to add the OpenCL_jll dependency.
With that, the host machine dont need to have OpenCL installed.