### PR TITLE
Don't install additional packages on CI

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,5 +10,5 @@ steps:
       queue: "juliagpu"
       cuda: "*"
     if: build.message !~ /\[skip tests\]/
-    command: "apt-get -y install nvidia-opencl-dev"
+    command: "mkdir -p /etc/OpenCL/vendors && echo libnvidia-opencl.so.1 > /etc/OpenCL/vendors/nvidia.icd"
     timeout_in_minutes: 60


### PR DESCRIPTION
I wanted to add some things to the previous PR, but it was merged quicker than I could push :-)

That said, I'd want to avoid installing any packages during CI, or at least install as few as possible. I'm wondering why we need anything, since out-of-the-box there's already an OpenCL driver available:

```
root@4a6a8922a176:/# find / | grep -i opencl
/usr/local/cuda-11.6/targets/x86_64-linux/lib/libOpenCL.so.1
/usr/local/cuda-11.6/targets/x86_64-linux/lib/libOpenCL.so.1.0
/usr/local/cuda-11.6/targets/x86_64-linux/lib/libOpenCL.so.1.0.0
/usr/local/cuda-11.6/targets/x86_64-linux/lib/libOpenCL.so
```