### PR TITLE
Fix macos with workaround

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -3,6 +3,7 @@ uuid = "08131aa3-fb12-5dee-8b74-c09406e224a2"
 version = "0.9.0"
 
 [deps]
+Libdl = "8f399da3-3557-5675-b5ff-fb832c97cbdb"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 OpenCL_jll = "6cb37087-e8b6-5417-8430-1f242f1e46e4"
 Printf = "de0858da-6303-5e67-8744-51eddeeeb8d7"

--- a/src/api.jl
+++ b/src/api.jl
@@ -2,9 +2,16 @@ module api
 
 include("types.jl")
 
-import OpenCL_jll
+@static if Sys.isapple()
+    import Libdl
 
-const libopencl = OpenCL_jll.libopencl
+    const paths = String["/System/Library/Frameworks/OpenCL.framework"]
+    const libopencl = Libdl.find_library(["libOpenCL", "OpenCL"], paths)
+else
+    import OpenCL_jll
+
+    const libopencl = OpenCL_jll.libopencl
+end
 
 function _ocl_func(func, ret_type, arg_types)
     local args_in = Symbol[Symbol("arg$i")


### PR DESCRIPTION
This is about issues #205 #206.
#196 introduced breaking changes for MacOS. 

!!! Consider this commit as a dirty workaround to get macos back running now. 

With version 0.9.0 of OpenCL.jl, the following output is returned for macos (x86).

```julia
julia> device, ctx, queue = cl.create_compute_context()
ERROR: CLError(code=-1001, CL_PLATFORM_NOT_FOUND_KHR)
Stacktrace:
 [1] macro expansion
   @ ~/.julia/packages/OpenCL/BTcrM/src/macros.jl:6 [inlined]
 [2] platforms()
   @ OpenCL.cl ~/.julia/packages/OpenCL/BTcrM/src/platform.jl:43
 [3] create_some_context()
   @ OpenCL.cl ~/.julia/packages/OpenCL/BTcrM/src/context.jl:277
 [4] create_compute_context()
   @ OpenCL.cl ~/.julia/packages/OpenCL/BTcrM/src/util.jl:2
 [5] top-level scope
   @ REPL[2]:1
```

This commit reverts the changes from #196 for macos, only. Other OS versions should not be affected. However, this requires to be validated by others. Following output is returned for my macos (x86).

```julia
julia> device, ctx, queue = cl.create_compute_context()
(OpenCL.Device(Intel(R) UHD Graphics 630 on Apple @0x0000000001024500), OpenCL.Context(@0x00007fdb11dcd260 on Intel(R) UHD Graphics 630), OpenCL.CmdQueue(@0x00007fdb143e26d0))
```

---

Fixing this bug properly, requires changes to the OpenCL_jll library. Roughly, the following steps are required:

```julia
...

# These are the platforms we will build for by default, unless further
# platforms are passed in on the command line
platforms = supported_platforms(; exclude=(Sys.iswindows || Sys.isapple))
platforms_macos = [ Platform("x86_64", "macos"), Platform("aarch64", "macos") ] # Support M-Series Processors as well?

# The products that we will ensure are always built
products = [
    LibraryProduct("libOpenCL", :libopencl)
]
products_macos = [
    FrameworkProduct("libOpenCL", :libopencl)
]

# Dependencies that must be installed before this package can be built
dependencies = [
    BuildDependency(PackageSpec(; name="OpenCL_Headers_jll", version=v"2022.09.23"))
]
dependencies_macos = [
    # At this point it is not clear to me, how to change OpenCL_Headers_jll.
]

# Build the tarballs, and possibly a `build.jl` as well.
if any(should_build_platform.(triplet.(platforms)))
    build_tarballs(ARGS, name, version, sources, script, platforms, products, dependencies; julia_compat="1.6", preferred_gcc_version = v"6.1.0")
end
if any(should_build_platform.(triplet.(platforms_macos)))
    build_tarballs(ARGS, name, version, sources, script, platforms_macos, products_macos, dependencies_macos; julia_compat="1.6", preferred_gcc_version = v"6.1.0")
end
```
