### PR TITLE
Support loading IL.

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+coverage:
+  ignore:
+    - "lib"
+    - "src/kernels"
+  status:
+    patch: false
+    project: false
+    changes: false

--- a/test/program.jl
+++ b/test/program.jl
@@ -65,14 +65,7 @@
             @test length(binaries[device]) > 0
             prg2 = cl.Program(ctx, binaries=binaries)
             @test prg2[:binaries] == binaries
-            try
-                prg2[:source]
-                error("should not happen")
-            catch err
-                @test isa(err, cl.CLError)
-                @test err.code == -45
-                @test err.desc == :CL_INVALID_PROGRAM_EXECUTABLE
-            end
+            @test prg2[:source] === nothing
         end
     end
 end


### PR DESCRIPTION
Requires `cl_khr_il_program`. Also remove the `binary` flag in `cl.Program`; it's only used to throw a slightly different error, while a `nothing` return seems more idiomatic to me.