### PR TITLE
Switch from getindex overloading to getproperty

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,9 @@ Breaking changes:
   `cl.devices()` have been removed.
 - The `Buffer` constructor has switched the `length` and `flags` around, for ambiguity
   reasons. The `length` argument is now also mandatory.
+- The `cl.info` method, and the `getindex` overloading to access properties of OpenCL
+  objects, have been replaced by `getproperty` overloading on the objects themselves
+  (e.g., `cl.info(dev, :name)` and `dev[:name]` are now simply `dev.name`).
 
 
 New features:

--- a/examples/hands_on_opencl/ex06/matmul.jl
+++ b/examples/hands_on_opencl/ex06/matmul.jl
@@ -127,7 +127,7 @@ for i in 1:COUNT
                                d_a, d_b, d_c)
 
         # profiling events are measured in ns
-        run_time = evt[:profile_duration] / 1e9
+        run_time = evt.profile_duration / 1e9
         cl.copy!(h_C, d_c)
         results(Mdim, Ndim, Pdim, h_C, run_time)
     end

--- a/examples/hands_on_opencl/ex07/matmul.jl
+++ b/examples/hands_on_opencl/ex07/matmul.jl
@@ -107,7 +107,7 @@ for i in 1:COUNT
                         Int32(Mdim), Int32(Ndim), Int32(Pdim),
                         d_a, d_b, d_c)
         # profiling events are measured in ns
-        run_time = evt[:profile_duration] / 1e9
+        run_time = evt.profile_duration / 1e9
         cl.copy!(h_C, d_c)
         results(Mdim, Ndim, Pdim, h_C, run_time)
     end
@@ -131,7 +131,7 @@ for i in 1:COUNT
         evt = mmul_ocl(Int32(Mdim), Int32(Ndim), Int32(Pdim), d_a, d_b, d_c)
 
         # profiling events are measured in ns
-        run_time = evt[:profile_duration] / 1e9
+        run_time = evt.profile_duration / 1e9
         cl.copy!(h_C, d_c)
         results(Mdim, Ndim, Pdim, h_C, run_time)
     end
@@ -143,7 +143,7 @@ end
 kernel_source = read(joinpath(src_dir, "C_row_priv.cl"), String)
 prg  = cl.Program(source=kernel_source) |> cl.build!
 mmul = cl.Kernel(prg, "mmul")
-wk_size = cl.info(cl.device(), :max_work_group_size)
+wk_size = cl.device().max_work_group_size
 if Ndim * (ORDER ÷ 16) >= wk_size
     @warn("Specified work_size $(Ndim * (ORDER ÷ 16)) is bigger than $wk_size")
 else
@@ -156,7 +156,7 @@ for i in 1:COUNT
                     Int32(Mdim), Int32(Ndim), Int32(Pdim),
                     d_a, d_b, d_c)
     # profiling events are measured in ns
-    run_time = evt[:profile_duration] / 1e9
+    run_time = evt.profile_duration / 1e9
     cl.copy!(h_C, d_c)
     results(Mdim, Ndim, Pdim, h_C, run_time)
 end

--- a/examples/hands_on_opencl/ex08/matmul.jl
+++ b/examples/hands_on_opencl/ex08/matmul.jl
@@ -107,7 +107,7 @@ for i in 1:COUNT
                         Int32(Mdim), Int32(Ndim), Int32(Pdim),
                         d_a, d_b, d_c)
         # profiling events are measured in ns
-        run_time = evt[:profile_duration] / 1e9
+        run_time = evt.profile_duration / 1e9
         cl.copy!(h_C, d_c)
         results(Mdim, Ndim, Pdim, h_C, run_time)
     end
@@ -130,7 +130,7 @@ for i in 1:COUNT
                         Int32(Mdim), Int32(Ndim), Int32(Pdim),
                         d_a, d_b, d_c)
         # profiling events are measured in ns
-        run_time = evt[:profile_duration] / 1e9
+        run_time = evt.profile_duration / 1e9
         cl.copy!(h_C, d_c)
         results(Mdim, Ndim, Pdim, h_C, run_time)
     end
@@ -142,7 +142,7 @@ end
 kernel_source = read(joinpath(src_dir, "C_row_priv_block.cl"), String)
 prg  = cl.Program(source=kernel_source) |> cl.build!
 mmul = cl.Kernel(prg, "mmul")
-wk_size = cl.info(cl.device(), :max_work_group_size)
+wk_size = cl.device().max_work_group_size
 if Ndim * (ORDER ÷ 16) >= wk_size
     @warn("Specified work_size is bigger than $wk_size")
 else
@@ -160,7 +160,7 @@ for i in 1:COUNT
                        d_a, d_b, d_c, localmem)
 
         # profiling events are measured in ns
-        run_time = evt[:profile_duration] / 1e9
+        run_time = evt.profile_duration / 1e9
         cl.copy!(h_C, d_c)
         results(Mdim, Ndim, Pdim, h_C, run_time)
     end
@@ -173,7 +173,7 @@ end
 kernel_source = read(joinpath(src_dir, "C_block_form.cl"), String)
 prg  = cl.Program(source=kernel_source) |> cl.build!
 mmul = cl.Kernel(prg, "mmul")
-wk_size = cl.info(cl.device(), :max_work_group_size)
+wk_size = cl.device().max_work_group_size
 if Ndim * (ORDER ÷ 16) >= wk_size
     @warn("Specified work_size is bigger than $wk_size")
 else
@@ -190,7 +190,7 @@ for i in 1:COUNT
                         Int32(Mdim), Int32(Ndim), Int32(Pdim),
                         d_a, d_b, d_c, localmem1, localmem2)
         # profiling events are measured in ns
-        run_time = evt[:profile_duration] / 1e9
+        run_time = evt.profile_duration / 1e9
         cl.copy!(h_C, d_c)
         results(Mdim, Ndim, Pdim, h_C, run_time)
     end

--- a/examples/hands_on_opencl/ex09/pi_ocl.jl
+++ b/examples/hands_on_opencl/ex09/pi_ocl.jl
@@ -35,16 +35,15 @@ program = cl.Program(source=kernelsource) |> cl.build!
 pi_kernel = cl.Kernel(program, "pi")
 
 # get the max work group size for the kernel pi on the device
-work_group_size = cl.device()[:max_work_group_size]
+work_group_size = cl.device().max_work_group_size
 
 # now that we know the size of the work_groups, we can set the number
 # of work groups, the actual number of steps, and the step size
 nwork_groups = in_nsteps ÷ (work_group_size * niters)
 
 if nwork_groups < 1
-    # you can get opencl object info through the obj[:symbol] syntax
-    # or cl.info(obj, :symbol)
-    nwork_groups = cl.device()[:max_compute_units]
+    # you can get opencl object info through the getproperty syntax
+    nwork_groups = cl.device().max_compute_units
     work_group_size = in_nsteps ÷ (nwork_groups * niters)
 end
 

--- a/examples/hands_on_opencl/exA/pi_vocl.jl
+++ b/examples/hands_on_opencl/exA/pi_vocl.jl
@@ -69,11 +69,11 @@ nwork_groups = in_nsteps ÷ (work_group_size * niters)
 
 # get the max work group size for the kernel on our device
 if vector_size == 1
-    max_size = cl.work_group_info(pi_kernel, :size, cl.device())
+    max_size = cl.work_group_info(pi_kernel, cl.device()).size
 elseif vector_size == 4
-    max_size = cl.work_group_info(pi_kernel, :size, cl.device())
+    max_size = cl.work_group_info(pi_kernel, cl.device()).size
 elseif vector_size == 8
-    max_size = cl.work_group_info(pi_kernel, :size, cl.device())
+    max_size = cl.work_group_info(pi_kernel, cl.device()).size
 end
 
 if max_size > work_group_size
@@ -82,7 +82,7 @@ if max_size > work_group_size
 end
 
 if nwork_groups < 1
-    nwork_groups = cl.device()[:max_compute_units]
+    nwork_groups = cl.device().max_compute_units
     work_group_size = in_nsteps ÷ (nwork_groups * niters)
 end
 

--- a/examples/performance.jl
+++ b/examples/performance.jl
@@ -48,29 +48,29 @@ function cl_performance(ndatapts::Integer, nworkers::Integer)
             cl.device!(device)
 
             @printf("====================================================\n")
-            @printf("Platform name:    %s\n",  platform[:name])
-            @printf("Platform profile: %s\n",  platform[:profile])
-            @printf("Platform vendor:  %s\n",  platform[:vendor])
-            @printf("Platform version: %s\n",  platform[:version])
+            @printf("Platform name:    %s\n",  platform.name)
+            @printf("Platform profile: %s\n",  platform.profile)
+            @printf("Platform vendor:  %s\n",  platform.vendor)
+            @printf("Platform version: %s\n",  platform.version)
             @printf("----------------------------------------------------\n")
-            @printf("Device name: %s\n", device[:name])
-            @printf("Device type: %s\n", device[:device_type])
-            @printf("Device mem: %i MB\n",           device[:global_mem_size] / 1024^2)
-            @printf("Device max mem alloc: %i MB\n", device[:max_mem_alloc_size] / 1024^2)
-            @printf("Device max clock freq: %i MHZ\n",  device[:max_clock_frequency])
-            @printf("Device max compute units: %i\n",   device[:max_compute_units])
-            @printf("Device max work group size: %i\n", device[:max_work_group_size])
-            @printf("Device max work item size: %s\n",  device[:max_work_item_size])
+            @printf("Device name: %s\n", device.name)
+            @printf("Device type: %s\n", device.device_type)
+            @printf("Device mem: %i MB\n",           device.global_mem_size / 1024^2)
+            @printf("Device max mem alloc: %i MB\n", device.max_mem_alloc_size / 1024^2)
+            @printf("Device max clock freq: %i MHZ\n",  device.max_clock_frequency)
+            @printf("Device max compute units: %i\n",   device.max_compute_units)
+            @printf("Device max work group size: %i\n", device.max_work_group_size)
+            @printf("Device max work item size: %s\n",  device.max_work_item_size)
 
-            if device[:max_mem_alloc_size] < sizeof(Float32) * ndatapts
+            if device.max_mem_alloc_size < sizeof(Float32) * ndatapts
                 @warn("Requested buffer size exceeds device max alloc size!")
-                @warn("Skipping device $(device[:name])...")
+                @warn("Skipping device $(device.name)...")
                 continue
             end
 
-            if device[:max_work_group_size] < nworkers
+            if device.max_work_group_size < nworkers
                 @warn("Number of workers exceeds the device's max work group size!")
-                @warn("Skipping device $(device[:name])...")
+                @warn("Skipping device $(device.name)...")
                 continue
             end
 
@@ -81,7 +81,7 @@ function cl_performance(ndatapts::Integer, nworkers::Integer)
             prg  = cl.Program(source=bench_kernel) |> cl.build!
             kern = cl.Kernel(prg, "sum")
 
-            # work_group_multiple = kern[:prefered_work_group_size_multiple]
+            # work_group_multiple = kern.prefered_work_group_size_multiple
             global_size = (ndatapts,)
             local_size  = (nworkers,)
 
@@ -90,7 +90,7 @@ function cl_performance(ndatapts::Integer, nworkers::Integer)
                 evt = kern[global_size, local_size](a_buf, b_buf, c_buf)
 
                 # duration in ns
-                t = evt[:profile_duration] * 1e-9
+                t = evt.profile_duration * 1e-9
                 @printf("Execution time of test: %.4f seconds\n", t)
 
                 c_device = cl.read(c_buf)

--- a/lib/buffer.jl
+++ b/lib/buffer.jl
@@ -189,11 +189,7 @@ function enqueue_copy_buffer(src::Buffer{T},
     evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
     ret_evt = Ref{cl_event}()
     if byte_count < 0
-        byte_count_src = Ref{Csize_t}()
-        byte_count_dst = Ref{Csize_t}()
-        clGetMemObjectInfo(src, CL_MEM_SIZE, sizeof(Csize_t), byte_count_src, C_NULL)
-        clGetMemObjectInfo(src, CL_MEM_SIZE, sizeof(Csize_t), byte_count_dst, C_NULL)
-        byte_count = min(byte_count_src[], byte_count_dst[])
+        byte_count = min(sizeof(src), sizeof(dst))
     end
     @assert byte_count > 0
     clEnqueueCopyBuffer(queue(), src, dst,
@@ -385,7 +381,7 @@ end
 # create an empty buffer similar to the passed in buffer
 function empty_like(b::Buffer{T}) where T
     len = length(b)
-    mf = info(b, :mem_flags)
+    mf = b.mem_flags
     if :r in mf
         return Buffer(T, len, :r)
     elseif :w in mf

--- a/lib/context.jl
+++ b/lib/context.jl
@@ -76,9 +76,9 @@ Base.unsafe_convert(::Type{cl_context}, ctx::Context) = ctx.id
 Base.pointer(ctx::Context) = ctx.id
 
 function Base.show(io::IO, ctx::Context)
-    dev_strs = [replace(d[:name], r"\s+" => " ") for d in devices(ctx)]
+    dev_strs = [replace(d.name, r"\s+" => " ") for d in ctx.devices]
     devs_str = join(dev_strs, ",")
-    ptr_val = convert(UInt, Base.pointer(ctx))
+    ptr_val = convert(UInt, pointer(ctx))
     ptr_address = "0x$(string(ptr_val, base = 16, pad = Sys.WORD_SIZE>>2))"
     print(io, "OpenCL.Context(@$ptr_address on $devs_str)")
 end
@@ -179,43 +179,62 @@ function Context(dev_type::Symbol;
             properties=properties, callback=callback)
 end
 
-
-function properties(ctx::Context)
-    nbytes = Ref{Csize_t}(0)
-    clGetContextInfo(ctx, CL_CONTEXT_PROPERTIES, 0, C_NULL, nbytes)
-
-    # Calculate length of storage array
-    # At nbytes[] the size of the properties array in bytes is stored
-    # The length of the property array is then nbytes[] / sizeof(cl_context_properties)
-    # Note: nprops should be odd since it requires a C_NULL terminated array
-    nprops = div(nbytes[], sizeof(cl_context_properties))
-
-    props = Vector{cl_context_properties}(undef, nprops)
-    clGetContextInfo(ctx, CL_CONTEXT_PROPERTIES, nbytes[], props, C_NULL)
-    #properties array of [key,value..., C_NULL]
-    result = Any[]
-    for i in 1:2:nprops
-        key = props[i]
-        value = i < nprops ? props[i+1] : nothing
-
-        if key == CL_CONTEXT_PLATFORM
-            push!(result, (key, Platform(cl_platform_id(value))))
-        elseif key == CL_GL_CONTEXT_KHR ||
-           key == CL_EGL_DISPLAY_KHR ||
-           key == CL_GLX_DISPLAY_KHR ||
-           key == CL_WGL_HDC_KHR ||
-           key == CL_CGL_SHAREGROUP_KHR
-            push!(result, (key, value))
-        elseif key == 0
-            if i != nprops
-                @warn("Encountered OpenCL.Context property key == 0 at position $i")
-            end
-            break
-        else
-            @warn("Unknown OpenCL.Context property key encountered $key")
+function Base.getproperty(ctx::Context, s::Symbol)
+    if s == :num_devices
+        ndevices = Ref{Cuint}()
+        clGetContextInfo(ctx, CL_CONTEXT_NUM_DEVICES, sizeof(Cuint), ndevices, C_NULL)
+        return Int(ndevices[])
+    elseif s == :devices
+        n = getproperty(ctx, :num_devices)
+        if n == 0
+            return Device[]
         end
+        dev_ids = Vector{cl_device_id}(undef, n)
+        clGetContextInfo(ctx, CL_CONTEXT_DEVICES, n * sizeof(cl_device_id), dev_ids, C_NULL)
+        return [Device(id) for id in dev_ids]
+    elseif s == :properties
+        nbytes = Ref{Csize_t}(0)
+        clGetContextInfo(ctx, CL_CONTEXT_PROPERTIES, 0, C_NULL, nbytes)
+
+        # Calculate length of storage array
+        # At nbytes[] the size of the properties array in bytes is stored
+        # The length of the property array is then nbytes[] / sizeof(cl_context_properties)
+        # Note: nprops should be odd since it requires a C_NULL terminated array
+        nprops = div(nbytes[], sizeof(cl_context_properties))
+
+        props = Vector{cl_context_properties}(undef, nprops)
+        clGetContextInfo(ctx, CL_CONTEXT_PROPERTIES, nbytes[], props, C_NULL)
+        #properties array of [key,value..., C_NULL]
+        result = Any[]
+        for i in 1:2:nprops
+            key = props[i]
+            value = i < nprops ? props[i+1] : nothing
+
+            if key == CL_CONTEXT_PLATFORM
+                push!(result, (key, Platform(cl_platform_id(value))))
+            elseif key == CL_GL_CONTEXT_KHR ||
+               key == CL_EGL_DISPLAY_KHR ||
+               key == CL_GLX_DISPLAY_KHR ||
+               key == CL_WGL_HDC_KHR ||
+               key == CL_CGL_SHAREGROUP_KHR
+                push!(result, (key, value))
+            elseif key == 0
+                if i != nprops
+                    @warn("Encountered OpenCL.Context property key == 0 at position $i")
+                end
+                break
+            else
+                @warn("Unknown OpenCL.Context property key encountered $key")
+            end
+        end
+        return result
+    elseif s == :reference_count
+        refcount = Ref{Cuint}()
+        clGetContextInfo(ctx, CL_CONTEXT_REFERENCE_COUNT, sizeof(Cuint), refcount, C_NULL)
+        return Int(refcount[])
+    else
+        return getfield(ctx, s)
     end
-    return result
 end
 
 #Note: properties list needs to be terminated with a NULL value!
@@ -250,18 +269,3 @@ function _parse_properties(props)
     return cl_props
 end
 
-function num_devices(ctx::Context)
-    ndevices = Ref{Cuint}()
-    clGetContextInfo(ctx, CL_CONTEXT_NUM_DEVICES, sizeof(Cuint), ndevices, C_NULL)
-    return ndevices[]
-end
-
-function devices(ctx::Context)
-    n = num_devices(ctx)
-    if n == 0
-        return []
-    end
-    dev_ids = Vector{cl_device_id}(undef, n)
-    clGetContextInfo(ctx, CL_CONTEXT_DEVICES, n * sizeof(cl_device_id), dev_ids, C_NULL)
-    return [Device(id) for id in dev_ids]
-end

--- a/lib/context.jl
+++ b/lib/context.jl
@@ -185,12 +185,12 @@ function Base.getproperty(ctx::Context, s::Symbol)
         clGetContextInfo(ctx, CL_CONTEXT_NUM_DEVICES, sizeof(Cuint), ndevices, C_NULL)
         return Int(ndevices[])
     elseif s == :devices
-        n = getproperty(ctx, :num_devices)
+        n = ctx.num_devices
         if n == 0
             return Device[]
         end
         dev_ids = Vector{cl_device_id}(undef, n)
-        clGetContextInfo(ctx, CL_CONTEXT_DEVICES, n * sizeof(cl_device_id), dev_ids, C_NULL)
+        clGetContextInfo(ctx, CL_CONTEXT_DEVICES, sizeof(dev_ids), dev_ids, C_NULL)
         return [Device(id) for id in dev_ids]
     elseif s == :properties
         nbytes = Ref{Csize_t}(0)

--- a/lib/device.jl
+++ b/lib/device.jl
@@ -10,55 +10,89 @@ Base.pointer(d::Device) = d.id
 
 function Base.show(io::IO, d::Device)
     strip_extra_whitespace = r"\s+"
-    device_name = replace(d[:name], strip_extra_whitespace => " ")
-    platform_name = replace(d[:platform][:name], strip_extra_whitespace => " ")
+    device_name = replace(d.name, strip_extra_whitespace => " ")
+    platform_name = replace(d.platform.name, strip_extra_whitespace => " ")
     ptr_val = convert(UInt, pointer(d))
     ptr_address = "0x$(string(ptr_val, base = 16, pad = Sys.WORD_SIZE>>2))"
     print(io, "OpenCL.Device($device_name on $platform_name @$ptr_address)")
 end
 
-Base.getindex(d::Device, dinfo::Symbol) = info(d, dinfo)
-
-macro int_info(func, cl_device_info, return_type)
-    quote
-        function $(esc(func))(d::Device)
-            result = Ref{$return_type}()
-            clGetDeviceInfo(d, $cl_device_info, sizeof($return_type), result, C_NULL)
-            return result[]
-        end
-    end
-end
-
-function info(d::Device, s::Symbol)
-
-    profile(d::Device) = begin
+function Base.getproperty(d::Device, s::Symbol)
+    # simple string properties
+    string_properties = Dict(
+        :profile        => CL_DEVICE_PROFILE,
+        :version        => CL_DEVICE_VERSION,
+        :driver_version => CL_DRIVER_VERSION,
+        :name           => CL_DEVICE_NAME,
+    )
+    if haskey(string_properties, s)
         size = Ref{Csize_t}()
-        clGetDeviceInfo(d, CL_DEVICE_PROFILE, 0, C_NULL, size)
+        clGetDeviceInfo(d, string_properties[s], 0, C_NULL, size)
         result = Vector{Cchar}(undef, size[])
-        clGetDeviceInfo(d, CL_DEVICE_PROFILE, size[], result, C_NULL)
-        bs = CLString(result)
-        return bs
+        clGetDeviceInfo(d, string_properties[s], size[], result, C_NULL)
+        return CLString(result)
     end
 
-    version(d::Device) = begin
-        size = Ref{Csize_t}()
-        clGetDeviceInfo(d, CL_DEVICE_VERSION, 0, C_NULL, size)
-        result = Vector{Cchar}(undef, size[])
-        clGetDeviceInfo(d, CL_DEVICE_VERSION, size[], result, C_NULL)
-        bs = CLString(result)
-        return bs
+    # scalar values
+    int_properties = Dict(
+        :queue_properties           => (CL_DEVICE_QUEUE_PROPERTIES, cl_command_queue_properties),
+        :exec_capabilities          => (CL_DEVICE_EXECUTION_CAPABILITIES, cl_device_exec_capabilities),
+        :vendor_id                  => (CL_DEVICE_VENDOR_ID,                 Cuint),
+        :max_compute_units          => (CL_DEVICE_MAX_COMPUTE_UNITS,         Cuint),
+        :max_work_item_dims         => (CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS,  Cuint),
+        :max_clock_frequency        => (CL_DEVICE_MAX_CLOCK_FREQUENCY,       Cuint),
+        :address_bits               => (CL_DEVICE_ADDRESS_BITS,              Cuint),
+        :max_read_image_args        => (CL_DEVICE_MAX_READ_IMAGE_ARGS,       Cuint),
+        :max_write_image_args       => (CL_DEVICE_MAX_WRITE_IMAGE_ARGS,      Cuint),
+        :global_mem_size            => (CL_DEVICE_GLOBAL_MEM_SIZE,           Culong),
+        :max_mem_alloc_size         => (CL_DEVICE_MAX_MEM_ALLOC_SIZE,        Culong),
+        :max_const_buffer_size      => (CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE,  Culong),
+        :local_mem_size             => (CL_DEVICE_LOCAL_MEM_SIZE,            Culong),
+        :max_work_group_size        => (CL_DEVICE_MAX_WORK_GROUP_SIZE,       Csize_t),
+        :max_parameter_size         => (CL_DEVICE_MAX_PARAMETER_SIZE,        Csize_t),
+        :profiling_timer_resolution => (CL_DEVICE_PROFILING_TIMER_RESOLUTION, Csize_t),
+    )
+    if haskey(int_properties, s)
+        prop, typ = int_properties[s]
+        result = Ref{typ}()
+        clGetDeviceInfo(d, prop, sizeof(typ), result, C_NULL)
+        return result[]
     end
 
-    driver_version(d::Device) = begin
-        size = Ref{Csize_t}()
-        clGetDeviceInfo(d, CL_DRIVER_VERSION, 0, C_NULL, size)
-        result = Vector{Cchar}(undef, size[])
-        clGetDeviceInfo(d, CL_DRIVER_VERSION, size[], result, C_NULL)
-        bs = CLString(result)
-        return string(replace(bs, r"\s+" => " "))
+    # boolean properties
+    bool_properties = Dict(
+        :has_image_support           => CL_DEVICE_IMAGE_SUPPORT,
+        :has_local_mem               => CL_DEVICE_LOCAL_MEM_TYPE,
+        :host_unified_memory         => CL_DEVICE_HOST_UNIFIED_MEMORY,
+        :available                   => CL_DEVICE_AVAILABLE,
+        :compiler_available          => CL_DEVICE_COMPILER_AVAILABLE
+    )
+    if haskey(bool_properties, s)
+        result = Ref{cl_bool}()
+        clGetDeviceInfo(d, bool_properties[s], sizeof(cl_bool), result, C_NULL)
+        return result[] == CL_TRUE
     end
 
-    extensions(d::Device) = begin
+    # boolean queue properties
+    # TODO: move this to `queue_info`?
+    queue_properties = Dict(
+        :has_queue_out_of_order_exec => CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE,
+        :has_queue_profiling         => CL_QUEUE_PROFILING_ENABLE,
+    )
+    if haskey(queue_properties, s)
+        return d.queue_properties & queue_properties[s] != 0
+    end
+
+    # boolean execution properties
+    # TODO: move this to `execution_info`?
+    exec_properties = Dict(
+        :has_native_kernel => CL_EXEC_NATIVE_KERNEL,
+    )
+    if haskey(exec_properties, s)
+        return d.exec_capabilities & exec_properties[s] != 0
+    end
+
+    if s == :extensions
         size = Ref{Csize_t}()
         clGetDeviceInfo(d, CL_DEVICE_EXTENSIONS, 0, C_NULL, size)
         result = Vector{Cchar}(undef, size[])
@@ -67,23 +101,14 @@ function info(d::Device, s::Symbol)
         return String[string(s) for s in split(bs)]
     end
 
-    platform(d::Device) = begin
+    if s == :platform
         result = Ref{cl_platform_id}()
         clGetDeviceInfo(d, CL_DEVICE_PLATFORM,
-                                   sizeof(cl_platform_id), result, C_NULL)
+                        sizeof(cl_platform_id), result, C_NULL)
         return Platform(result[])
     end
 
-    name(d::Device) = begin
-        size = Ref{Csize_t}()
-        clGetDeviceInfo(d, CL_DEVICE_NAME, 0, C_NULL, size)
-        result = Vector{Cchar}(undef, size[])
-        clGetDeviceInfo(d, CL_DEVICE_NAME, size[] * sizeof(Cchar), result, C_NULL)
-        n = CLString(result)
-        return string(replace(n, r"\s+" => " "))
-    end
-
-    device_type(d::Device) = begin
+    if s == :device_type
         result = Ref{cl_device_type}()
         clGetDeviceInfo(d, CL_DEVICE_TYPE, sizeof(cl_device_type), result, C_NULL)
         result = result[]
@@ -100,65 +125,7 @@ function info(d::Device, s::Symbol)
         end
     end
 
-    has_image_support(d::Device) = begin
-        has_support = Ref{cl_bool}(CL_FALSE)
-        clGetDeviceInfo(d, CL_DEVICE_IMAGE_SUPPORT, sizeof(cl_bool), has_support, C_NULL)
-        return has_support[] == CL_TRUE
-    end
-
-    @int_info(queue_properties, CL_DEVICE_QUEUE_PROPERTIES, cl_command_queue_properties)
-
-    has_queue_out_of_order_exec(d::Device) =
-        (queue_properties(d) & CL_QUEUE_OUT_OF_ORDER_EXEC_MODE_ENABLE) != 0
-
-    has_queue_profiling(d::Device) =
-        (queue_properties(d) & CL_QUEUE_PROFILING_ENABLE) != 0
-
-    has_native_kernel(d::Device) = begin
-        result = Ref{cl_device_exec_capabilities}()
-        clGetDeviceInfo(d, CL_DEVICE_EXECUTION_CAPABILITIES,
-                        sizeof(cl_device_exec_capabilities), result, C_NULL)
-        return (result[] & CL_EXEC_NATIVE_KERNEL) != 0
-    end
-
-    @int_info(vendor_id,             CL_DEVICE_VENDOR_ID,                Cuint)
-    @int_info(max_compute_units,     CL_DEVICE_MAX_COMPUTE_UNITS,        Cuint)
-    @int_info(max_work_item_dims,    CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, Cuint)
-    @int_info(max_clock_frequency,   CL_DEVICE_MAX_CLOCK_FREQUENCY,      Cuint)
-    @int_info(address_bits,          CL_DEVICE_ADDRESS_BITS,             Cuint)
-    @int_info(max_read_image_args,   CL_DEVICE_MAX_READ_IMAGE_ARGS,      Cuint)
-    @int_info(max_write_image_args,  CL_DEVICE_MAX_WRITE_IMAGE_ARGS,     Cuint)
-    @int_info(global_mem_size,       CL_DEVICE_GLOBAL_MEM_SIZE,          Culong)
-    @int_info(max_mem_alloc_size,    CL_DEVICE_MAX_MEM_ALLOC_SIZE,       Culong)
-    @int_info(max_const_buffer_size, CL_DEVICE_MAX_CONSTANT_BUFFER_SIZE, Culong)
-    @int_info(local_mem_size,        CL_DEVICE_LOCAL_MEM_SIZE,           Culong)
-
-    has_local_mem(d::Device) = begin
-        result = Ref{cl_device_local_mem_type}()
-        clGetDeviceInfo(d, CL_DEVICE_LOCAL_MEM_TYPE,
-                        sizeof(cl_device_local_mem_type), result, C_NULL)
-        return result[] == CL_LOCAL
-    end
-
-    host_unified_memory(d::Device) = begin
-        result = Ref{cl_bool}(CL_FALSE)
-        clGetDeviceInfo(d, CL_DEVICE_HOST_UNIFIED_MEMORY, sizeof(cl_bool), result, C_NULL)
-        return result[] == CL_TRUE
-    end
-
-    available(d::Device) = begin
-        result = Ref{cl_bool}(CL_FALSE)
-        clGetDeviceInfo(d, CL_DEVICE_AVAILABLE, sizeof(cl_bool), result, C_NULL)
-        return result[] == CL_TRUE
-    end
-
-    compiler_available(d::Device) = begin
-        result = Ref{cl_bool}(CL_FALSE)
-        clGetDeviceInfo(d, CL_DEVICE_COMPILER_AVAILABLE, sizeof(cl_bool), result, C_NULL)
-        return result[] == CL_TRUE
-    end
-
-    max_work_item_size(d::Device) = begin
+    if s == :max_work_item_size
         dims = Ref{Cuint}()
         clGetDeviceInfo(d, CL_DEVICE_MAX_WORK_ITEM_DIMENSIONS, sizeof(Cuint), dims, C_NULL)
         result = Vector{Csize_t}(undef, dims[])
@@ -166,11 +133,7 @@ function info(d::Device, s::Symbol)
         return tuple([Int(r) for r in result]...)
     end
 
-    @int_info(max_work_group_size, CL_DEVICE_MAX_WORK_GROUP_SIZE, Csize_t)
-    @int_info(max_parameter_size, CL_DEVICE_MAX_PARAMETER_SIZE,  Csize_t)
-    @int_info(profiling_timer_resolution, CL_DEVICE_PROFILING_TIMER_RESOLUTION, Csize_t)
-
-    max_image2d_shape(d::Device) = begin
+    if s == :max_image2d_shape
         width  = Ref{Csize_t}()
         height = Ref{Csize_t}()
         clGetDeviceInfo(d, CL_DEVICE_IMAGE2D_MAX_WIDTH, sizeof(Csize_t), width,  C_NULL)
@@ -178,7 +141,7 @@ function info(d::Device, s::Symbol)
         return (width[], height[])
     end
 
-    max_image3d_shape(d::Device) = begin
+    if s == :max_image3d_shape
         width  = Ref{Csize_t}()
         height = Ref{Csize_t}()
         depth =  Ref{Csize_t}()
@@ -188,52 +151,7 @@ function info(d::Device, s::Symbol)
         return (width[], height[], depth[])
     end
 
-    info_map = Dict{Symbol, Function}(
-        :driver_version => driver_version,
-        :version => version,
-        :profile => profile,
-        :extensions => extensions,
-        :platform => platform,
-        :name => name,
-        :device_type => device_type,
-        :has_image_support => has_image_support,
-        :queue_properties => queue_properties,
-        :has_queue_out_of_order_exec => has_queue_out_of_order_exec,
-        :has_queue_profiling => has_queue_profiling,
-        :has_native_kernel => has_native_kernel,
-        :vendor_id => vendor_id,
-        :max_compute_units => max_compute_units,
-        :max_work_item_size => max_work_item_size,
-        :max_clock_frequency => max_clock_frequency,
-        :address_bits => address_bits,
-        :max_read_image_args => max_read_image_args,
-        :max_write_image_args => max_write_image_args,
-        :global_mem_size => global_mem_size,
-        :max_mem_alloc_size => max_mem_alloc_size,
-        :max_const_buffer_size => max_const_buffer_size,
-        :local_mem_size => local_mem_size,
-        :has_local_mem => has_local_mem,
-        :host_unified_memory => host_unified_memory,
-        :available => available,
-        :compiler_available => compiler_available,
-        :max_work_group_size => max_work_group_size,
-        :max_work_item_dims => max_work_item_dims,
-        :max_parameter_size => max_parameter_size,
-        :profiling_timer_resolution => profiling_timer_resolution,
-        :max_image2d_shape => max_image2d_shape,
-        :max_image3d_shape => max_image3d_shape
-    )
-
-    try
-        func = info_map[s]
-        func(d)
-    catch err
-        if isa(err, KeyError)
-            throw(ArgumentError("OpenCL.Device has no info for: $s"))
-        else
-            throw(err)
-        end
-    end
+    return getfield(d, s)
 end
 
 function cl_device_type(dtype::Symbol)

--- a/lib/event.jl
+++ b/lib/event.jl
@@ -257,11 +257,11 @@ function Base.getproperty(evt::CLEvent, s::Symbol)
     if s == :context
         ctx = Ref{cl_context}()
         clGetEventInfo(evt, CL_EVENT_CONTEXT, sizeof(cl_context), ctx, C_NULL)
-        return Context(ctx[], retain=true)
+        return Context(ctx[])
     elseif s == :command_queue
         cmd_q = Ref{cl_command_queue}()
         clGetEventInfo(evt, CL_EVENT_COMMAND_QUEUE, sizeof(cl_command_queue), cmd_q, C_NULL)
-        return CmdQueue(cmd_q[], retain=true)
+        return CmdQueue(cmd_q[])
     elseif s == :command_type
         cmd_t = Ref{Cint}()
         clGetEventInfo(evt, CL_EVENT_COMMAND_TYPE, sizeof(Cint), cmd_t, C_NULL)

--- a/lib/kernel.jl
+++ b/lib/kernel.jl
@@ -24,13 +24,11 @@ Base.unsafe_convert(::Type{cl_kernel}, k::Kernel) = k.id
 Base.pointer(k::Kernel) = k.id
 
 Base.show(io::IO, k::Kernel) = begin
-    print(io, "OpenCL.Kernel(\"$(k[:name])\" nargs=$(k[:num_args]))")
+    print(io, "OpenCL.Kernel(\"$(k.name)\" nargs=$(k.num_args))")
 end
 
-Base.getindex(k::Kernel, kinfo::Symbol) = info(k, kinfo)
-
 function Kernel(p::Program, kernel_name::String)
-    for (dev, status) in info(p, :build_status)
+    for (dev, status) in p.build_status
         if status != CL_BUILD_SUCCESS
             msg = "OpenCL.Program has to be built before Kernel constructor invoked"
             throw(ArgumentError(msg))
@@ -221,40 +219,40 @@ function set_args!(k::Kernel, args...)
     end
 end
 
-function work_group_info(k::Kernel, winfo, d::Device)
-    if (winfo == CL_KERNEL_LOCAL_MEM_SIZE ||
-        winfo == CL_KERNEL_PRIVATE_MEM_SIZE)
+function work_group_info(k::Kernel, s, d::Device)
+    if (s == CL_KERNEL_LOCAL_MEM_SIZE ||
+        s == CL_KERNEL_PRIVATE_MEM_SIZE)
         result1 = Ref{Culong}(0)
-        clGetKernelWorkGroupInfo(k, d, winfo, sizeof(Culong), result1, C_NULL)
+        clGetKernelWorkGroupInfo(k, d, s, sizeof(Culong), result1, C_NULL)
         return Int(result1[])
-    elseif winfo == CL_KERNEL_COMPILE_WORK_GROUP_SIZE
+    elseif s == CL_KERNEL_COMPILE_WORK_GROUP_SIZE
         # Intel driver has a bug so we can't query the required size.
         # As specified by [1] the return value in this case is size_t[3].
         # [1] https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelWorkGroupInfo.html
         @assert sizeof(Csize_t) == sizeof(Int)
         result2 = Vector{Int}(undef, 3)
-        clGetKernelWorkGroupInfo(k, d, winfo, 3*sizeof(Int), result2, C_NULL)
+        clGetKernelWorkGroupInfo(k, d, s, 3*sizeof(Int), result2, C_NULL)
         return result2
     else
         result = Ref{Csize_t}(0)
-        clGetKernelWorkGroupInfo(k, d, winfo, sizeof(Culong), result, C_NULL)
+        clGetKernelWorkGroupInfo(k, d, s, sizeof(Culong), result, C_NULL)
         return Int(result[])
     end
 end
 
-function work_group_info(k::Kernel, winfo::Symbol, d::Device)
-    if winfo == :size
+function work_group_info(k::Kernel, s::Symbol, d::Device)
+    if s == :size
         work_group_info(k, CL_KERNEL_WORK_GROUP_SIZE, d)
-    elseif winfo == :compile_size
+    elseif s == :compile_size
         work_group_info(k, CL_KERNEL_COMPILE_WORK_GROUP_SIZE, d)
-    elseif winfo == :local_mem_size
+    elseif s == :local_mem_size
         work_group_info(k, CL_KERNEL_LOCAL_MEM_SIZE, d)
-    elseif winfo == :private_mem_size
+    elseif s == :private_mem_size
         work_group_info(k, CL_KERNEL_PRIVATE_MEM_SIZE, d)
-    elseif winfo == :prefered_size_multiple
+    elseif s == :prefered_size_multiple
         work_group_info(k, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, d)
     else
-        throw(ArgumentError(("Unknown work_group_info flag: :$winfo")))
+        throw(ArgumentError(("Unknown work_group_info flag: :$s")))
     end
 end
 
@@ -299,7 +297,7 @@ function enqueue_kernel(k::Kernel,
                         local_work_size;
                         global_work_offset=nothing,
                         wait_on::Union{Nothing,Vector{Event}}=nothing)
-    max_work_dim = device()[:max_work_item_dims]
+    max_work_dim = device().max_work_item_dims
     work_dim     = length(global_work_size)
     if work_dim > max_work_dim
         throw(ArgumentError("global_work_size has max dim of $max_work_dim"))
@@ -370,61 +368,77 @@ function enqueue_task(k::Kernel; wait_for=nothing)
     return ret_event[]
 end
 
-function info(k::Kernel, kinfo::Symbol)
-    name(k::Kernel) = begin
+function Base.getproperty(k::Kernel, s::Symbol)
+    if s == :function_name
         size = Ref{Csize_t}()
         clGetKernelInfo(k, CL_KERNEL_FUNCTION_NAME, 0, C_NULL, size)
         result = Vector{Cchar}(undef, size[])
-        clGetKernelInfo(k, CL_KERNEL_FUNCTION_NAME, size[], result, size)
-        return CLString(result)
-    end
-
-    num_args(k::Kernel) = begin
-        ret = Ref{Cuint}()
-        clGetKernelInfo(k, CL_KERNEL_NUM_ARGS, sizeof(Cuint), ret, C_NULL)
-        return ret[]
-    end
-
-    reference_count(k::Kernel) = begin
-        ret = Ref{Cuint}()
-        clGetKernelInfo(k, CL_KERNEL_REFERENCE_COUNT, sizeof(Cuint), ret, C_NULL)
-        return ret[]
-    end
-
-    program(k::Kernel) = begin
-        ret = Ref{cl_program}()
-        clGetKernelInfo(k, CL_KERNEL_PROGRAM, sizeof(cl_program), ret, C_NULL)
-        return Program(ret[], retain=true)
-    end
-
-    # Only supported for version 1.2 and above
-    attributes(k::Kernel) = begin
+        clGetKernelInfo(k, CL_KERNEL_FUNCTION_NAME, size[], result, C_NULL)
+        return unsafe_string(pointer(result))
+    elseif s == :num_args
+        result = Ref{Cuint}()
+        clGetKernelInfo(k, CL_KERNEL_NUM_ARGS, sizeof(Cuint), result, C_NULL)
+        return Int(result[])
+    elseif s == :reference_count
+        result = Ref{Cuint}()
+        clGetKernelInfo(k, CL_KERNEL_REFERENCE_COUNT, sizeof(Cuint), result, C_NULL)
+        return Int(result[])
+    elseif s == :context
+        result = Ref{cl_context}()
+        clGetKernelInfo(k, CL_KERNEL_CONTEXT, sizeof(cl_context), result, C_NULL)
+        return Context(result[], retain=true)
+    elseif s == :program
+        result = Ref{cl_program}()
+        clGetKernelInfo(k, CL_KERNEL_PROGRAM, sizeof(cl_program), result, C_NULL)
+        return Program(result[], retain=true)
+    elseif s == :attributes
         size = Ref{Csize_t}()
-        rcode = unchecked_clGetKernelInfo(k, CL_KERNEL_ATTRIBUTES,
-                                          0, C_NULL, size)
-        # Version 1.1 mostly MESA drivers will pass through the below condition
-        if rcode == CL_INVALID_VALUE || size[] <= 1
+        err = unchecked_clGetKernelInfo(k, CL_KERNEL_ATTRIBUTES, 0, C_NULL, size)
+        if err == CL_SUCCESS && size[] > 1
+            result = Vector{Cchar}(undef, size[])
+            clGetKernelInfo(k, CL_KERNEL_ATTRIBUTES, size[], result, C_NULL)
+            return unsafe_string(pointer(result))
+        else
             return ""
         end
-        result = Vector{Cchar}(undef, size[])
-        clGetKernelInfo(k, CL_KERNEL_ATTRIBUTES, size[], result, size)
-        return CLString(result)
+    else
+        return getfield(k, s)
     end
+end
 
-    info_map = Dict{Symbol, Function}(
-        :name => name,
-        :num_args => num_args,
-        :reference_count => reference_count,
-        :program => program,
-        :attributes => attributes
-    )
+struct KernelWorkGroupInfo
+    kernel::Kernel
+    device::Device
+end
+work_group_info(k::Kernel, d::Device) = KernelWorkGroupInfo(k, d)
 
-    try
-        func = info_map[kinfo]
-        func(k)
-    catch err
-        isa(err, KeyError) && error("OpenCL.Kernel has no info for: $kinfo")
-        throw(err)
+function Base.getproperty(ki::KernelWorkGroupInfo, s::Symbol)
+    k = getfield(ki, :kernel)
+    d = getfield(ki, :devic)
+
+    function get(param_name::cl_kernel_work_group_info, ::Type{T}) where T
+        result = Ref{T}()
+        clGetKernelWorkGroupInfo(k, d, param_name, sizeof(T), result, C_NULL)
+        return result[]
+    end
+    if s == :size
+        return get(k, CL_KERNEL_WORK_GROUP_SIZE, Csize_t, d)
+    elseif s == :compile_size
+        # Intel driver has a bug so we can't query the required size.
+        # As specified by [1] the return value in this case is size_t[3].
+        # [1] https://www.khronos.org/registry/OpenCL/sdk/1.2/docs/man/xhtml/clGetKernelWorkGroupInfo.html
+        @assert sizeof(Csize_t) == sizeof(Int)
+        result = Vector{Int}(undef, 3)
+        clGetKernelWorkGroupInfo(k, d, winfo, 3*sizeof(Int), result, C_NULL)
+        return result
+    elseif s == :local_mem_size
+        return get(k, CL_KERNEL_LOCAL_MEM_SIZE, Culong, d)
+    elseif s == :private_mem_size
+        return get(k, CL_KERNEL_PRIVATE_MEM_SIZE, Culong, d)
+    elseif s == :prefered_size_multiple
+        return get(k, CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE, Csize_t, d)
+    else
+        throw(ArgumentError("Unknown work_group_info flag: :$s"))
     end
 end
 

--- a/lib/memory.jl
+++ b/lib/memory.jl
@@ -13,11 +13,7 @@ Base.unsafe_convert(::Type{cl_mem}, mem::CLMemObject) = mem.id
 
 Base.pointer(mem::CLMemObject) = mem.id
 
-Base.sizeof(mem::CLMemObject) = begin
-    val = Ref{Csize_t}(0)
-    clGetMemObjectInfo(mem, CL_MEM_SIZE, sizeof(Csize_t), val, C_NULL)
-    return val[]
-end
+Base.sizeof(mem::CLMemObject) = mem.size
 
 function _finalize(mem::CLMemObject)
     if !mem.valid
@@ -30,25 +26,20 @@ function _finalize(mem::CLMemObject)
     mem.valid = false
 end
 
-context(mem::CLMemObject) = begin
-    param = Ref{cl_context}()
-    clGetMemObjectInfo(mem, CL_MEM_CONTEXT, sizeof(Csize_t), param, C_NULL)
-    return Context(param[], retain=true)
-end
+context(mem::CLMemObject) = mem.context
 
-function info(mem::CLMemObject, minfo::Symbol)
-
-    mem_type(m::CLMemObject) = begin
+function Base.getproperty(mem::CLMemObject, s::Symbol)
+    if s == :context
+        param = Ref{cl_context}()
+        clGetMemObjectInfo(mem, CL_MEM_CONTEXT, sizeof(cl_context), param, C_NULL)
+        return Context(param[], retain=true)
+    elseif s == :mem_type
         result = Ref{cl_mem_object_type}()
-        clGetMemObjectInfo(m.id, CL_MEM_TYPE,
-                        sizeof(cl_mem_object_type), result, C_NULL)
+        clGetMemObjectInfo(mem, CL_MEM_TYPE, sizeof(cl_mem_object_type), result, C_NULL)
         return result[]
-    end
-
-    mem_flags(m::CLMemObject) = begin
+    elseif s == :mem_flags
         result = Ref{cl_mem_flags}()
-        clGetMemObjectInfo(m.id, CL_MEM_FLAGS,
-                        sizeof(cl_mem_flags), result, C_NULL)
+        clGetMemObjectInfo(mem, CL_MEM_FLAGS, sizeof(cl_mem_flags), result, C_NULL)
         mf = result[]
         flags = Symbol[]
         if (mf & CL_MEM_READ_WRITE) != 0
@@ -70,46 +61,20 @@ function info(mem::CLMemObject, minfo::Symbol)
             push!(flags, :copy)
         end
         return tuple(flags...)
-    end
-
-    size(m::CLMemObject) = begin
+    elseif s == :size
         result = Ref{Csize_t}()
-        clGetMemObjectInfo(m.id, CL_MEM_SIZE,
-                        sizeof(Csize_t), result, C_NULL)
+        clGetMemObjectInfo(mem, CL_MEM_SIZE, sizeof(Csize_t), result, C_NULL)
         return result[]
-    end
-
-    reference_count(m::CLMemObject) = begin
+    elseif s == :reference_count
         result = Ref{Cuint}()
-        clGetMemObjectInfo(m.id, CL_MEM_REFERENCE_COUNT,
-                        sizeof(Cuint), result, C_NULL)
-        return result[]
-    end
-
-    map_count(m::CLMemObject) = begin
+        clGetMemObjectInfo(mem, CL_MEM_REFERENCE_COUNT, sizeof(Cuint), result, C_NULL)
+        return Int(result[])
+    elseif s == :map_count
         result = Ref{Cuint}()
-        clGetMemObjectInfo(m.id, CL_MEM_MAP_COUNT,
-                        sizeof(Cuint), result, C_NULL)
-        return result[]
-    end
-
-    info_map = Dict{Symbol, Function}(
-        :mem_type => mem_type,
-        :mem_flags => mem_flags,
-        :size => size,
-        :reference_count => reference_count,
-        :map_count => map_count
-    )
-
-    try
-        func = info_map[minfo]
-        func(mem)
-    catch err
-        if isa(err, KeyError)
-            throw(ArgumentError("OpenCL.MemObject has no info for: $minfo"))
-        else
-            throw(err)
-        end
+        clGetMemObjectInfo(mem, CL_MEM_MAP_COUNT, sizeof(Cuint), result, C_NULL)
+        return Int(result[])
+    else
+        return getfield(mem, s)
     end
 end
 

--- a/lib/platform.jl
+++ b/lib/platform.jl
@@ -8,33 +8,36 @@ Base.unsafe_convert(::Type{cl_platform_id}, p::Platform) = p.id
 
 Base.pointer(p::Platform) = p.id
 
-function info(p::Platform, pinfo::Symbol)
-    info_map = Dict{Symbol, cl_platform_info}(
-        :profile => CL_PLATFORM_PROFILE,
-        :version => CL_PLATFORM_VERSION,
-        :name    => CL_PLATFORM_NAME,
-        :vendor  => CL_PLATFORM_VENDOR,
-        :extensions => CL_PLATFORM_EXTENSIONS
+function Base.getproperty(p::Platform, s::Symbol)
+    # string properties
+    string_properties = Dict(
+        :profile    => CL_PLATFORM_PROFILE,
+        :version    => CL_PLATFORM_VERSION,
+        :name       => CL_PLATFORM_NAME,
+        :vendor     => CL_PLATFORM_VENDOR,
     )
-    try
-        cl_info = info_map[pinfo]
-        inf = info(p, cl_info)
-        pinfo == :extensions && return split(inf)
-        return inf
-    catch err
-        if isa(err, KeyError)
-            throw(ArgumentError("OpenCL.Platform has no info for: $pinfo"))
-        else
-            throw(err)
-        end
+    if haskey(string_properties, s)
+        size = Ref{Csize_t}()
+        clGetPlatformInfo(p, string_properties[s], 0, C_NULL, size)
+        result = Vector{Cchar}(undef, size[])
+        clGetPlatformInfo(p, string_properties[s], size[], result, C_NULL)
+        return CLString(result)
     end
-end
 
-Base.getindex(p::Platform, pinfo::Symbol) = info(p, pinfo)
+    if s == :extensions
+        size = Ref{Csize_t}()
+        clGetPlatformInfo(p, CL_PLATFORM_EXTENSIONS, 0, C_NULL, size)
+        result = Vector{Cchar}(undef, size[])
+        clGetPlatformInfo(p, CL_PLATFORM_EXTENSIONS, size[], result, C_NULL)
+        return split(CLString(result))
+    end
+
+    return getfield(p, s)
+end
 
 function Base.show(io::IO, p::Platform)
     strip_extra_whitespace = r"\s+"
-    platform_name = replace(p[:name], strip_extra_whitespace => " ")
+    platform_name = replace(p.name, strip_extra_whitespace => " ")
     ptr_val = convert(UInt, Base.pointer(p))
     ptr_address = "0x$(string(ptr_val, base = 16, pad = Sys.WORD_SIZE>>2))"
     print(io, "OpenCL.Platform('$platform_name' @$ptr_address)")
@@ -52,14 +55,6 @@ function num_platforms()
     nplatforms = Ref{Cuint}()
     clGetPlatformIDs(0, C_NULL, nplatforms)
     return Int(nplatforms[])
-end
-
-function info(p::Platform, pinfo)
-    size = Ref{Csize_t}()
-    clGetPlatformInfo(p, pinfo, 0, C_NULL, size)
-    result = Vector{Cchar}(undef, size[])
-    clGetPlatformInfo(p, pinfo, size[], result, C_NULL)
-    return CLString(result)
 end
 
 function devices(p::Platform, dtype)
@@ -91,5 +86,5 @@ end
 
 has_device_type(p::Platform, dtype) = length(devices(p, dtype)) > 0
 
-available_devices(p::Platform, dtype::Symbol) = filter(d -> info(d, :available),  devices(p, dtype))
+available_devices(p::Platform, dtype::Symbol) = filter(d -> d.available,  devices(p, dtype))
 available_devices(p::Platform) = available_devices(p, :all)

--- a/lib/program.jl
+++ b/lib/program.jl
@@ -32,8 +32,6 @@ Base.unsafe_convert(::Type{cl_program}, p::Program) = p.id
 
 Base.pointer(p::Program) = p.id
 
-Base.getindex(p::Program, pinfo::Symbol) = info(p, pinfo)
-
 function Program(; source=nothing, binaries=nothing, il=nothing)
     if count(!isnothing, (source, binaries, il)) != 1
         throw(ArgumentError("Program must be source, binary, or intermediate language"))
@@ -95,13 +93,13 @@ function build!(p::Program; options = "", raise = true)
     ndevices = 0
     device_ids = C_NULL
     err = unchecked_clBuildProgram(p, cl_uint(ndevices), device_ids, opts, C_NULL, C_NULL)
-    for (dev, status) in cl.info(p, :build_status)
+    for (dev, status) in p.build_status
         if status == cl.CL_BUILD_ERROR
             println(stderr, "Couldn't compile kernel: ")
-            source = info(p, :source)
+            source = p.source
             print_with_linenumbers(source, "    ", stderr)
             println(stderr, "With following build error:")
-            println(stderr, cl.info(p, :build_log)[dev])
+            println(stderr, p.build_log[dev])
             raise && err # throw the build error when raise!
         end
     end
@@ -111,124 +109,63 @@ function build!(p::Program; options = "", raise = true)
     return p
 end
 
-function info(p::Program, pinfo::Symbol)
-    num_devices(p::Program) = begin
-        ret = Ref{Cuint}()
-        clGetProgramInfo(p, CL_PROGRAM_NUM_DEVICES, sizeof(ret), ret, C_NULL)
-        return ret[]
-    end
-
-    devices(p::Program) = begin
-        ndevices = num_devices(p)
+function Base.getproperty(p::Program, s::Symbol)
+    if s == :reference_count
+        count = Ref{Cuint}()
+        clGetProgramInfo(p, CL_PROGRAM_REFERENCE_COUNT, sizeof(Cuint), count, C_NULL)
+        return Int(count[])
+    elseif s == :num_devices
+        count = Ref{Cuint}()
+        clGetProgramInfo(p, CL_PROGRAM_NUM_DEVICES, sizeof(Cuint), count, C_NULL)
+        return Int(count[])
+    elseif s == :devices
+        ndevices = getproperty(p, :num_devices)
         device_ids = Vector{cl_device_id}(undef, ndevices)
-        clGetProgramInfo(p, CL_PROGRAM_DEVICES,
-                         sizeof(cl_device_id) * ndevices, device_ids, C_NULL)
-        return [Device(device_ids[i]) for i in 1:ndevices]
-    end
-
-    build_status(p::Program) = begin
+        clGetProgramInfo(p, CL_PROGRAM_DEVICES, sizeof(cl_device_id) * ndevices, device_ids, C_NULL)
+        return [Device(id) for id in device_ids]
+    elseif s == :source
+        size = Ref{Csize_t}()
+        clGetProgramInfo(p, CL_PROGRAM_SOURCE, 0, C_NULL, size)
+        source = Vector{Cchar}(undef, size[])
+        clGetProgramInfo(p, CL_PROGRAM_SOURCE, size[], source, C_NULL)
+        return unsafe_string(pointer(source))
+    elseif s == :binary_sizes
+        ndevices = getproperty(p, :num_devices)
+        sizes = Vector{Csize_t}(undef, ndevices)
+        clGetProgramInfo(p, CL_PROGRAM_BINARY_SIZES, sizeof(Csize_t) * ndevices, sizes, C_NULL)
+        return sizes
+    elseif s == :binaries
+        sizes = getproperty(p, :binary_sizes)
+        binaries = [Vector{UInt8}(undef, size) for size in sizes]
+        pointers = [pointer(binary) for binary in binaries]
+        clGetProgramInfo(p, CL_PROGRAM_BINARIES, sizeof(Ptr{UInt8}) * length(pointers), pointers, C_NULL)
+        return binaries
+    elseif s == :context
+        ctx = Ref{cl_context}()
+        clGetProgramInfo(p, CL_PROGRAM_CONTEXT, sizeof(cl_context), ctx, C_NULL)
+        return Context(ctx[], retain=true)
+    elseif s == :build_status
+        devices = getproperty(p, :devices)
         status_dict = Dict{Device, cl_build_status}()
-        status = Ref{cl_build_status}()
-        for d in devices(p)
-            clGetProgramBuildInfo(p, d, CL_PROGRAM_BUILD_STATUS,
-                                  sizeof(cl_build_status), status, C_NULL)
-            status_dict[d] = status[]
+        for device in devices
+            status = Ref{cl_build_status}()
+            clGetProgramBuildInfo(p, device, CL_PROGRAM_BUILD_STATUS, sizeof(cl_build_status), status, C_NULL)
+            status_dict[device] = status[]
         end
         return status_dict
-    end
-
-    build_logs(p::Program) = begin
-        logs = Dict{Device, String}()
-        for d in devices(p)
-            log_len = Ref{Csize_t}()
-            clGetProgramBuildInfo(p, d, CL_PROGRAM_BUILD_LOG, 0, C_NULL, log_len)
-            if log_len[] == 0
-                logs[d] = ""
-                continue
-            end
-            log_bytestring = Vector{Cchar}(undef, log_len[])
-            clGetProgramBuildInfo(p, d, CL_PROGRAM_BUILD_LOG,
-                                  log_len[], log_bytestring, C_NULL)
-            logs[d] = CLString(log_bytestring)
+    elseif s == :build_log
+        devices = getproperty(p, :devices)
+        log_dict = Dict{Device, String}()
+        for device in devices
+            size = Ref{Csize_t}()
+            clGetProgramBuildInfo(p, device, CL_PROGRAM_BUILD_LOG, 0, C_NULL, size)
+            log = Vector{Cchar}(undef, size[])
+            clGetProgramBuildInfo(p, device, CL_PROGRAM_BUILD_LOG, size[], log, C_NULL)
+            log_dict[device] = unsafe_string(pointer(log))
         end
-        return logs
-    end
-
-    binaries(p::Program) = begin
-        binary_dict = Dict{Device, Array{UInt8}}()
-        slen = Ref{Csize_t}()
-        clGetProgramInfo(p, CL_PROGRAM_BINARY_SIZES, 0, C_NULL, slen)
-
-        sizes = zeros(Csize_t, slen[])
-        clGetProgramInfo(p, CL_PROGRAM_BINARY_SIZES, slen[], sizes, C_NULL)
-        bins = Vector{Ptr{UInt8}}(undef, length(sizes))
-        # keep a reference to the underlying binary arrays
-        # as storing the pointer to the array hides the additional
-        # reference from julia's garbage collector
-        bin_arrays = Any[]
-        for (i, s) in enumerate(sizes)
-            if s > 0
-                bin = Vector{UInt8}(undef, s)
-                bins[i] = pointer(bin)
-                push!(bin_arrays, bin)
-            else
-                bins[i] = Base.unsafe_convert(Ptr{UInt8}, C_NULL)
-            end
-        end
-        clGetProgramInfo(p, CL_PROGRAM_BINARIES,
-                         length(sizes) * sizeof(Ptr{UInt8}),
-                         bins, C_NULL)
-        bidx = 1
-        for (i, d) in enumerate(devices(p))
-            if sizes[i] > 0
-                binary_dict[d] = bin_arrays[bidx]
-                bidx += 1
-            end
-        end
-        return binary_dict
-    end
-
-    source(p::Program) = begin
-        src_len = Ref{Csize_t}()
-        clGetProgramInfo(p, CL_PROGRAM_SOURCE, 0, C_NULL, src_len)
-        src_len[] <= 1 && return nothing
-        src = Vector{Cchar}(undef, src_len[])
-        clGetProgramInfo(p, CL_PROGRAM_SOURCE, src_len[], src, C_NULL)
-        return CLString(src)
-    end
-
-    context(p::Program) = begin
-        ret = Ref{cl_context}()
-        clGetProgramInfo(p, CL_PROGRAM_CONTEXT, sizeof(cl_context), ret, C_NULL)
-        return Context(ret[], retain = true)
-    end
-
-    reference_count(p::Program) = begin
-        ret = Ref{Cuint}()
-        clGetProgramInfo(p, CL_PROGRAM_REFERENCE_COUNT, sizeof(Cuint), ret, C_NULL)
-        return ret[]
-    end
-
-    info_map = Dict{Symbol, Function}(
-        :reference_count => reference_count,
-        :devices => devices,
-        :context => context,
-        :num_devices => num_devices,
-        :source => source,
-        :binaries => binaries,
-        :build_log => build_logs,
-        :build_status => build_status,
-    )
-
-    try
-        func = info_map[pinfo]
-        func(p)
-    catch err
-        if isa(err, KeyError)
-            throw(ArgumentError("OpenCL.Program has no info for $pinfo"))
-        else
-            throw(err)
-        end
+        return log_dict
+    else
+        return getfield(p, s)
     end
 end
 

--- a/lib/program.jl
+++ b/lib/program.jl
@@ -94,7 +94,7 @@ function build!(p::Program; options = "", raise = true)
     device_ids = C_NULL
     err = unchecked_clBuildProgram(p, cl_uint(ndevices), device_ids, opts, C_NULL, C_NULL)
     for (dev, status) in p.build_status
-        if status == cl.CL_BUILD_ERROR
+        if status == CL_BUILD_ERROR
             println(stderr, "Couldn't compile kernel: ")
             source = p.source
             print_with_linenumbers(source, "    ", stderr)

--- a/lib/state.jl
+++ b/lib/state.jl
@@ -12,7 +12,7 @@ function platform()
 
         # prefer platforms that implement the full profile
         full_platform = findfirst(platforms) do platform
-            info(platform, :profile) == "FULL_PROFILE"
+            platform.profile == "FULL_PROFILE"
         end
         isnothing(full_platform) || return platforms[full_platform]
 
@@ -35,12 +35,12 @@ function platform!(name::String)
     platforms = cl.platforms()
 
     name_match = findfirst(platforms) do platform
-        contains(lowercase(info(platform, :name)), lowercase(name))
+        contains(lowercase(platform.name), lowercase(name))
     end
     isnothing(name_match) || return platform!(platforms[name_match])
 
     vendor_match = findfirst(platforms) do platform
-        contains(lowercase(info(platform, :vendor)), lowercase(name))
+        contains(lowercase(platform.vendor), lowercase(name))
     end
     isnothing(vendor_match) || return platform!(platforms[vendor_match])
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -92,8 +92,8 @@ const TRANSPOSE_FLOAT_PROGRAM_PATH = joinpath(@__DIR__, "kernels", "transpose_fl
 const TRANSPOSE_DOUBLE_PROGRAM_PATH = joinpath(@__DIR__, "kernels", "transpose_double.cl")
 
 function max_block_size(h::Int, w::Int)
-    dim1, dim2 = cl.info(device(), :max_work_item_size)[1:2]
-    wgsize = cl.info(device(), :max_work_group_size)
+    dim1, dim2 = cl.device().max_work_item_size[1:2]
+    wgsize = cl.device().max_work_group_size
     wglimit = floor(Int, sqrt(wgsize))
     return gcd(dim1, dim2, h, w, wglimit)
 end
@@ -122,7 +122,7 @@ end
 
 """Transpose CLMatrix A, write result to a preallicated CLMatrix B"""
 function LinearAlgebra.transpose!(B::CLMatrix{Float64}, A::CLMatrix{Float64})
-    if !in("cl_khr_fp64", cl.info(device(), :extensions))
+    if !in("cl_khr_fp64", cl.device().extensions)
         throw(ArgumentError("Double precision not supported by device"))
     end
     block_size = max_block_size(size(A, 1), size(A, 2))

--- a/src/util.jl
+++ b/src/util.jl
@@ -9,9 +9,9 @@ function parse_version(version_string)
                                  parse(Int, mg.captures[2]))
 end
 
-opencl_version(obj::CLObject) = parse_version(obj[:version])
-opencl_version(c::cl.Context)  = opencl_version(first(cl.devices(c)))
-opencl_version(q::cl.CmdQueue) = opencl_version(q[:device])
+opencl_version(obj::CLObject) = parse_version(obj.version)
+opencl_version(c::cl.Context)  = opencl_version(first(c.devices))
+opencl_version(q::cl.CmdQueue) = opencl_version(q.device)
 
 """
 Format string using dict-like variables, replacing all accurancies of

--- a/test/behaviour.jl
+++ b/test/behaviour.jl
@@ -1,9 +1,3 @@
-#=
-info(
-"======================================================================
-                              Running Behavior Tests
-      ======================================================================")
-=#
 @testset "Hello World Test" begin
     hello_world_kernel = "
         #pragma OPENCL EXTENSION cl_khr_byte_addressable_store : enable

--- a/test/cmdqueue.jl
+++ b/test/cmdqueue.jl
@@ -6,7 +6,7 @@
             cl.CmdQueue(:out_of_order)
             cl.CmdQueue((:profile, :out_of_order))
         catch err
-            @warn("Platform $(cl.device()[:platform][:name]) does not seem to " *
+            @warn("Platform $(cl.device().platform.name) does not seem to " *
                   "suport out of order queues: \n$err",maxlog=1,
                   exception=(err, catch_backtrace()))
         end
@@ -19,9 +19,9 @@
 
     @testset "info" begin
         q = cl.CmdQueue()
-        @test q[:context] == cl.context()
-        @test q[:device] == cl.device()
-        @test q[:reference_count] > 0
-        @test typeof(q[:properties]) == cl.cl_command_queue_properties
+        @test q.context == cl.context()
+        @test q.device == cl.device()
+        @test q.reference_count > 0
+        @test typeof(q.properties) == cl.cl_command_queue_properties
     end
 end

--- a/test/context.jl
+++ b/test/context.jl
@@ -70,15 +70,15 @@ end
             @test cl.Context(sym_dev_type, properties=properties) != nothing
             @test cl.Context(cl_dev_type, properties=properties) != nothing
             ctx = cl.Context(cl_dev_type, properties=properties)
-            @test isempty(cl.properties(ctx)) == false
-            test_properties = cl.properties(ctx)
+            @test !isempty(ctx.properties)
+            test_properties = ctx.properties
 
             @test test_properties == properties
 
             platform_in_properties = false
             for (t, v) in test_properties
                 if t == cl.CL_CONTEXT_PLATFORM
-                    @test v[:name] == cl.platform()[:name]
+                    @test v.name == cl.platform().name
                     @test v == cl.platform()
                     platform_in_properties = true
                     break

--- a/test/device.jl
+++ b/test/device.jl
@@ -9,7 +9,7 @@
             #end
             #devices = cl.devices(cl.platform(), k)
             #for device in devices
-            #    @fact device[:device_type] == t --> true
+            #    @fact device.device_type == t --> true
             #end
         end
     end
@@ -62,26 +62,26 @@
                 :max_image3d_shape,
             ]
         @test isa(cl.platform(), cl.Platform)
-        @test_throws ArgumentError cl.platform()[:zjdlkf]
+        @test_throws ErrorException cl.platform().zjdlkf
 
         device = cl.device()
         @test isa(device, cl.Device)
-        @test_throws ArgumentError device[:zjdlkf]
+        @test_throws ErrorException device.zjdlkf
         for k in device_info_keys
-            @test device[k] == cl.info(device, k)
+            v = getproperty(device, k)
             if k == :extensions
-                @test isa(device[k], Array)
-                if length(device[k]) > 0
-                    @test isa(device[k], Array{String, 1})
+                @test isa(v, Array)
+                if length(v) > 0
+                    @test isa(v, Array{String, 1})
                 end
             elseif k == :platform
-                @test device[k] == cl.platform()
+                @test v == cl.platform()
             elseif k == :max_work_item_sizes
-                @test length(device[k]) == 3
+                @test length(v) == 3
             elseif k == :max_image2d_shape
-                @test length(device[k]) == 2
+                @test length(v) == 2
             elseif k == :max_image3d_shape
-                @test length(device[k]) == 3
+                @test length(v) == 3
             end
         end
     end

--- a/test/event.jl
+++ b/test/event.jl
@@ -6,10 +6,10 @@ else
 @testset "Event" begin
     @testset "status" begin
         evt = cl.UserEvent()
-        evt[:status]
-        @test evt[:status] == :submitted
+        evt.status
+        @test evt.status == :submitted
         cl.complete(evt)
-        @test evt[:status] == :complete
+        @test evt.status == :complete
         finalize(evt)
     end
 
@@ -21,14 +21,14 @@ else
         # create marker event
         mkr_evt = cl.enqueue_marker()
 
-        @test usr_evt[:status] == :submitted
-        @test mkr_evt[:status] in (:queued, :submitted)
+        @test usr_evt.status == :submitted
+        @test mkr_evt.status in (:queued, :submitted)
 
         cl.complete(usr_evt)
-        @test usr_evt[:status] == :complete
+        @test usr_evt.status == :complete
 
         cl.wait(mkr_evt)
-        @test mkr_evt[:status] == :complete
+        @test mkr_evt.status == :complete
 
         @test cl.cl_event_status(:running) == cl.CL_RUNNING
         @test cl.cl_event_status(:submitted) == cl.CL_SUBMITTED
@@ -50,12 +50,12 @@ else
         mkr_evt = cl.enqueue_marker()
         cl.add_callback(mkr_evt, test_callback)
 
-        @test usr_evt[:status] == :submitted
-        @test mkr_evt[:status] in (:queued, :submitted)
+        @test usr_evt.status == :submitted
+        @test mkr_evt.status in (:queued, :submitted)
         @test !callback_called[]
 
         cl.complete(usr_evt)
-        @test usr_evt[:status] == :complete
+        @test usr_evt.status == :complete
 
         cl.wait(mkr_evt)
 
@@ -63,7 +63,7 @@ else
         yield()
         sleep(0.5)
 
-        @test mkr_evt[:status] == :complete
+        @test mkr_evt.status == :complete
         @test callback_called[]
     end
 end

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -31,11 +31,11 @@ end
         prg = cl.Program(source=test_source)
         cl.build!(prg)
         k = cl.Kernel(prg, "sum")
-        @test k[:name] == "sum"
-        @test k[:num_args] == 4
-        @test k[:reference_count] > 0
-        @test k[:program] == prg
-        @test typeof(k[:attributes]) == String
+        @test k.function_name == "sum"
+        @test k.num_args == 4
+        @test k.reference_count > 0
+        @test k.program == prg
+        @test typeof(k.attributes) == String
     end
 
     @testset "mem/workgroup size" begin
@@ -122,7 +122,7 @@ end
         @test_throws ArgumentError cl.launch(k, (1,1), (1,), d_buff)
 
         # dimensions are bounded
-        max_work_dim = cl.device()[:max_work_item_dims]
+        max_work_dim = cl.device().max_work_item_dims
         bad = tuple([1 for _ in 1:(max_work_dim + 1)])
         @test_throws MethodError cl.launch(k, bad, d_buff)
 

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -42,16 +42,9 @@ end
         prg = cl.Program(source=test_source)
         cl.build!(prg)
         k = cl.Kernel(prg, "sum")
-        for (sf, clf) in [(:size, cl.CL_KERNEL_WORK_GROUP_SIZE),
-                          (:compile_size, cl.CL_KERNEL_COMPILE_WORK_GROUP_SIZE),
-                          (:local_mem_size, cl.CL_KERNEL_LOCAL_MEM_SIZE),
-                          (:private_mem_size, cl.CL_KERNEL_PRIVATE_MEM_SIZE),
-                          (:prefered_size_multiple, cl.CL_KERNEL_PREFERRED_WORK_GROUP_SIZE_MULTIPLE)]
-            @test cl.work_group_info(k, sf, cl.device()) != nothing
-            @test cl.work_group_info(k, clf, cl.device()) != nothing
-            if sf != :compile_size
-                @test cl.work_group_info(k, sf, cl.device()) == cl.work_group_info(k, clf, cl.device())
-            end
+        wginfo = cl.work_group_info(k, cl.device())
+        for sf in [:size, :compile_size, :local_mem_size, :private_mem_size, :prefered_size_multiple]
+            @test getproperty(wginfo, sf) != nothing
         end
     end
 

--- a/test/memory.jl
+++ b/test/memory.jl
@@ -26,7 +26,7 @@ end
 
         for expectation in expectations
             prop, value = expectation
-            @test cl.info(buf, prop) == value
+            @test getproperty(buf, prop) == value
         end
     end
 end

--- a/test/platform.jl
+++ b/test/platform.jl
@@ -4,9 +4,6 @@
 
         @test cl.platform() != nothing
         @test pointer(cl.platform()) != C_NULL
-        for k in [:profile, :version, :name, :vendor, :extensions]
-            @test cl.platform()[k] == cl.info(cl.platform(), k)
-        end
         v = opencl_version(cl.platform())
         @test 1 <= v.major <= 3
         @test 0 <= v.minor <= 2

--- a/test/program.jl
+++ b/test/program.jl
@@ -25,30 +25,30 @@
     @testset "info" begin
         prg = cl.Program(source=test_source)
 
-        @test prg[:context] == cl.context()
+        @test prg.context == cl.context()
 
-        @test typeof(prg[:devices]) == Vector{cl.Device}
-        @test length(prg[:devices]) > 0
-        @test cl.device() in prg[:devices]
+        @test typeof(prg.devices) == Vector{cl.Device}
+        @test length(prg.devices) > 0
+        @test cl.device() in prg.devices
 
-        @test typeof(prg[:source]) == String
-        @test prg[:source] == test_source
+        @test typeof(prg.source) == String
+        @test prg.source == test_source
 
-        @test prg[:reference_count] > 0
-        @test isempty(strip(prg[:build_log][cl.device()]))
+        @test prg.reference_count > 0
+        @test isempty(strip(prg.build_log[cl.device()]))
     end
 
     @testset "build" begin
         prg = cl.Program(source=test_source)
         @test cl.build!(prg) != nothing
 
-        @test prg[:build_status][cl.device()] == cl.CL_BUILD_SUCCESS
-        @test prg[:build_log][cl.device()] isa String
+        @test prg.build_status[cl.device()] == cl.CL_BUILD_SUCCESS
+        @test prg.build_log[cl.device()] isa String
     end
 
     @testset "source code" begin
        prg = cl.Program(source=test_source)
-       @test prg[:source] == test_source
+       @test prg.source == test_source
     end
 
     if backend == "pocl"
@@ -57,14 +57,14 @@
         @testset "binaries" begin
             prg = cl.Program(source=test_source) |> cl.build!
 
-            @test cl.device() in collect(keys(prg[:binaries]))
-            binaries = prg[:binaries]
+            @test cl.device() in collect(keys(prg.binaries))
+            binaries = prg.binaries
             @test cl.device() in collect(keys(binaries))
             @test binaries[cl.device()] != nothing
             @test length(binaries[cl.device()]) > 0
             prg2 = cl.Program(binaries=binaries)
-            @test prg2[:binaries] == binaries
-            @test prg2[:source] === nothing
+            @test prg2.binaries == binaries
+            @test prg2.source === nothing
         end
     end
 end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -7,8 +7,8 @@ if backend == "pocl"
 end
 cl.platform!(backend)
 @info """Testing using $backend back-end
-         - platform: $(cl.info(cl.platform(), :name))
-         - device: $(cl.info(cl.device(), :name))
+         - platform: $(cl.platform().name)
+         - device: $(cl.device().name)
 
          To test with a different back-end, define JULIA_OPENCL_BACKEND."""
 


### PR DESCRIPTION
Presumably this was done before `getproperty` overloading was a thing.

I also removed the `cl.info` method because of !TMTOWTDI, but I'd be fine with only supporting `getproperty` on a struct returned by `info` if anybody objects (I did it the other way around because `cl.info(cl.device()).name` looks a bit silly).