### PR TITLE
Add a simple versioninfo function.

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,28 @@ using Pkg
 Pkg.add("OpenCL")
 ```
 
+3. Test your installation:
+
+```julia-repl
+julia> OpenCL.versioninfo()
+OpenCL.jl version 0.10.0
+
+Toolchain:
+ - Julia v1.10.5
+ - OpenCL_jll v2024.5.8+1
+
+Available platforms: 3
+ - Portable Computing Language
+   version: OpenCL 3.0 PoCL 6.0  Linux, Release, RELOC, SPIR-V, LLVM 15.0.7jl, SLEEF, DISTRO, POCL_DEBUG
+   · cpu-haswell-AMD Ryzen 9 5950X 16-Core Processor (fp64, il)
+ - NVIDIA CUDA
+   version: OpenCL 3.0 CUDA 12.6.65
+   · NVIDIA RTX 6000 Ada Generation (fp64)
+ - Intel(R) OpenCL Graphics
+   version: OpenCL 3.0
+   · Intel(R) Arc(TM) A770 Graphics (fp16, il)
+```
+
 
 ## Basic example: vector add
 

--- a/lib/api.jl
+++ b/lib/api.jl
@@ -82,7 +82,12 @@ const initialized = Ref{Bool}(false)
         return
     end
 
-    withenv("OCL_ICD_FILENAMES"=>join(OpenCL_jll.drivers, ':')) do
+    ocd_filenames = join(OpenCL_jll.drivers, ':')
+    if haskey(ENV, "OCL_ICD_FILENAMES")
+        ocd_filenames *= ":" * ENV["OCL_ICD_FILENAMES"]
+    end
+
+    withenv("OCL_ICD_FILENAMES"=>ocd_filenames) do
         num_platforms = Ref{Cuint}()
         @ccall libopencl.clGetPlatformIDs(
             0::cl_uint, C_NULL::Ptr{cl_platform_id},

--- a/src/util.jl
+++ b/src/util.jl
@@ -46,3 +46,49 @@ function get_kernel(program_file::String, kernel_name::String; vars...)
         return kernel
     end
 end
+
+function versioninfo(io::IO=stdout)
+    println(io, "OpenCL.jl version $(pkgversion(@__MODULE__))")
+    println(io)
+
+    println(io, "Toolchain:")
+    println(io, " - Julia v$(VERSION)")
+    for pkg in [cl.OpenCL_jll]
+        println(io, " - $(string(pkg)) v$(pkgversion(pkg))")
+    end
+    println(io)
+
+    env = filter(var->startswith(var, "JULIA_OPENCL"), keys(ENV))
+    if !isempty(env)
+        println(io, "Environment:")
+        for var in env
+            println(io, "- $var: $(ENV[var])")
+        end
+        println(io)
+    end
+
+    println(io, "Available platforms: ", length(cl.platforms()))
+    for platform in cl.platforms()
+        println(io, " - $(platform.name)")
+        println(io, "   version: $(platform.version)")
+        for device in cl.devices(platform)
+            print(io, "   · $(device.name)")
+
+            ## list some relevant extensions
+            extensions = []
+            if in("cl_khr_fp16", device.extensions)
+                push!(extensions, "fp16")
+            end
+            if in("cl_khr_fp64", device.extensions)
+                push!(extensions, "fp64")
+            end
+            if in("cl_khr_il_program", device.extensions)
+                push!(extensions, "il")
+            end
+            if !isempty(extensions)
+                print(io, " (", join(extensions, ", "), ")")
+            end
+            println(io)
+        end
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,8 @@ using Test
 using OpenCL
 using pocl_jll
 
+@info "System information:\n" * sprint(io->OpenCL.versioninfo(io))
+
 @testset "OpenCL.jl" begin
 
 @testset "$(platform.name): $(device.name)" for platform in cl.platforms(),


### PR DESCRIPTION
```julia-repl
julia> OpenCL.versioninfo()
OpenCL.jl version 0.10.0

Toolchain:
 - Julia v1.10.5
 - OpenCL_jll v2024.5.8+1

Available platforms: 3
 - Portable Computing Language
   version: OpenCL 3.0 PoCL 6.0  Linux, Release, RELOC, SPIR-V, LLVM 15.0.7jl, SLEEF, DISTRO, POCL_DEBUG
   · cpu-haswell-AMD Ryzen 9 5950X 16-Core Processor (fp64, il)
 - NVIDIA CUDA
   version: OpenCL 3.0 CUDA 12.6.65
   · NVIDIA RTX 6000 Ada Generation (fp64)
 - Intel(R) OpenCL Graphics
   version: OpenCL 3.0
   · Intel(R) Arc(TM) A770 Graphics (fp16, il)
```