### PR TITLE
Use the platform OpenCL library on Apple.

### DIFF
--- a/lib/api.jl
+++ b/lib/api.jl
@@ -1,6 +1,9 @@
-import OpenCL_jll
-
-const libopencl = OpenCL_jll.libopencl
+const libopencl = if Sys.isapple()
+    "/System/Library/Frameworks/OpenCL.framework/OpenCL"
+else
+    import OpenCL_jll
+    OpenCL_jll.libopencl
+end
 
 """
     @checked function foo(...)
@@ -76,6 +79,8 @@ const initialized = Ref{Bool}(false)
 @noinline function initialize()
     initialized[] = true
 
+    Sys.isapple() && return
+
     if isempty(OpenCL_jll.drivers)
         @warn """No OpenCL driver JLLs were detected at the time of the first call into OpenCL.jl.
                  Only system drivers will be available."""
@@ -96,7 +101,9 @@ const initialized = Ref{Bool}(false)
 end
 
 function __init__()
-    if !OpenCL_jll.is_available()
+    if Sys.isapple()
+        @warn "on macOS, OpenCL.jl uses the system OpenCL framework, which is deprecated."
+    elseif !OpenCL_jll.is_available()
         @error "OpenCL_jll is not available for your platform, OpenCL.jl. will not work."
     end
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -53,7 +53,11 @@ function versioninfo(io::IO=stdout)
 
     println(io, "Toolchain:")
     println(io, " - Julia v$(VERSION)")
-    for pkg in [cl.OpenCL_jll]
+    pkgs = []
+    if !Sys.isapple()
+        push!(pkgs, OpenCL_jll)
+    end
+    for pkg in pkgs
         println(io, " - $(string(pkg)) v$(pkgversion(pkg))")
     end
     println(io)


### PR DESCRIPTION
Fixes https://github.com/JuliaGPU/OpenCL.jl/issues/205

I'm not inclined to merge this, though. Apple has deprecated OpenCL, only supporting v1.2, which is ancient. I'll leave this up in case somebody really needs this, and wants to finish this. That would either involve making everything compatible with OpenCL v1.2, or introducing an opt-in preference to use the system OpenCL platform for backwards compatibility.