### PR TITLE
Buffer rework

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -13,8 +13,9 @@ Breaking changes:
   and set (`cl.platform!(platform)`, `cl.device!(device)`, etc) as needed.
 - As part of the above change, questionable APIs like `cl.create_some_context()` and
   `cl.devices()` have been removed.
-- The `Buffer` constructor has switched the `length` and `flags` around, for ambiguity
-  reasons. The `length` argument is now also mandatory.
+- The `Buffer` API has been completely reworked. It now only provides low-level
+  functionality, such as `unsafe_copyto!` or `unsafe_map!`, while high-level functionality
+  like `copy!` is implemented for the `CLArray` type.
 - The `cl.info` method, and the `getindex` overloading to access properties of OpenCL
   objects, have been replaced by `getproperty` overloading on the objects themselves
   (e.g., `cl.info(dev, :name)` and `dev[:name]` are now simply `dev.name`).

--- a/NEWS.md
+++ b/NEWS.md
@@ -24,6 +24,8 @@ Breaking changes:
   kernels match the OpenCL argument types (i.e., no empty types, 4-element tuples for
   a 3-element `float3` arguments).
 - The `to_host` function has been replaced by simply calling `Array` on the `CLArray`.
+- Queue and execution capabilities of a device are now to be queried using dedicated
+  functions, `cl.queue_properties` and `cl.exec_capabilities`.
 
 New features:
 

--- a/lib/CL.jl
+++ b/lib/CL.jl
@@ -2,7 +2,7 @@ module cl
 
 export CLObject
 
-abstract type CLObject end
+abstract type CLObject end  # XXX: remove this
 
 Base.hash(x::CLObject) = hash(pointer(x))
 Base.isequal(x::T, y::T) where {T <: CLObject} = Base.hash(x) == Base.hash(y)

--- a/lib/buffer.jl
+++ b/lib/buffer.jl
@@ -1,412 +1,176 @@
 # OpenCL.Buffer
 
-mutable struct Buffer{T} <: CLMemObject
-    valid::Bool
+mutable struct Buffer{T} <: AbstractMemory
     id::cl_mem
     len::Int
-    mapped::Bool
-    hostbuf::Ptr{T}
 
-    function Buffer{T}(mem_id::cl_mem, retain::Bool, len::Integer) where T #hostbuf
-        @assert len > 0
-        @assert mem_id != C_NULL
+    function Buffer{T}(mem_id::cl_mem, len::Integer; retain::Bool=false) where {T}
         if retain
             clRetainMemObject(mem_id)
         end
-        nbytes = sizeof(T) * len
-        buff = new{T}(true, mem_id, len, false, C_NULL)
-        finalizer(buff) do mem_obj
-            if !mem_obj.valid
-                throw(CLMemoryError("Attempted to double free OpenCL.Buffer $mem_obj"))
-            end
-            _finalize(mem_obj)
-            mem_obj.valid   = false
-            mem_obj.mapped  = false
-            mem_obj.hostbuf = C_NULL
+        buff = new{T}(mem_id, len)
+        finalizer(buff) do x
+            _finalize(x)
         end
         return buff
     end
 end
 
-Base.unsafe_convert(::Type{cl_mem}, b::Buffer) = b.id
-
 Base.ndims(b::Buffer) = 1
 Base.eltype(b::Buffer{T}) where {T} = T
-Base.length(b::Buffer{T}) where {T} = Int(b.len)
-Base.sizeof(b::Buffer{T}) where {T} = Int(b.len * sizeof(T))
+Base.length(b::Buffer{T}) where {T} = b.len
+Base.sizeof(b::Buffer{T}) where {T} = b.len * sizeof(T)
 
-Base.show(io::IO, b::Buffer{T}) where {T} = begin
-    ptr_val = convert(UInt, Base.pointer(b))
-    ptr_address = "0x$(string(ptr_val, base = 16, pad = Sys.WORD_SIZE>>2))"
-    print(io, "Buffer{$T}(@$ptr_address)")
-end
 
-# XXX: conflict between integer flags and length.
-#      design is messy. probably best move all flags into a kwarg?
+## constructors
 
-# high level Buffer constructors with symbol flags
-function Buffer(::Type{T}, len::Integer; hostbuf=nothing) where T
-    Buffer(T, len, (:rw, :null), hostbuf=hostbuf)
-end
+# for internal use
+function Buffer{T}(len::Int, flags::Integer, hostbuf=nothing;
+                   device=:rw, host=:rw) where {T}
+    sz = len * sizeof(T)
 
-function Buffer(::Type{T}, len::Integer, mem_flag::Symbol; hostbuf=nothing) where T
-    Buffer(T, len, (mem_flag, :null), hostbuf=hostbuf)
-end
-
-function Buffer(::Type{T}, len::Integer, mem_flags::NTuple{2, Symbol}; hostbuf=nothing) where T
-    f_r  = :r  in mem_flags
-    f_w  = :w  in mem_flags
-    f_rw = :rw in mem_flags
-
-    if f_r && f_w || f_r && f_rw || f_rw && f_w
-        throw(ArgumentError("only one flag in {:r, :w, :rw} can be defined"))
-    end
-
-    local flags::cl_mem_flags
-    if f_rw && !(f_r || f_w)
-        flags = CL_MEM_READ_WRITE
-    elseif f_r && !(f_w || f_rw)
-        flags = CL_MEM_READ_ONLY
-    elseif f_w && !(f_r || f_rw)
-        flags = CL_MEM_WRITE_ONLY
+    if device == :rw
+        flags |= CL_MEM_READ_WRITE
+    elseif device == :r
+        flags |= CL_MEM_READ_ONLY
+    elseif device == :w
+        flags |= CL_MEM_WRITE_ONLY
     else
-        # default buffer is read/write
-        flags = CL_MEM_READ_WRITE
+        throw(ArgumentError("Device access flag must be one of :rw, :r, or :w"))
     end
 
-    f_alloc = :alloc in mem_flags
-    f_use   = :use   in mem_flags
-    f_copy  = :copy  in mem_flags
-    if f_alloc && f_use || f_alloc && f_copy || f_use && f_copy
-        throw(ArgumentError("only one flag in {:alloc, :use, :copy} can be defined"))
-    end
-
-    if f_alloc && !(f_use || f_copy)
-        flags |= CL_MEM_ALLOC_HOST_PTR
-    elseif f_use && !(f_alloc || f_copy)
-        flags |= CL_MEM_USE_HOST_PTR
-    elseif f_copy && !(f_alloc || f_use)
-        flags |= CL_MEM_COPY_HOST_PTR
-    end
-    return Buffer(T, len, flags, hostbuf=hostbuf)
-end
-
-# low level Buffer constructor with integer parameter flags
-function Buffer(::Type{T}, len::Integer, flags;
-                hostbuf::Union{Nothing,Array{T}}=nothing) where T
-
-    if (hostbuf !== nothing &&
-        (flags & (CL_MEM_USE_HOST_PTR | CL_MEM_COPY_HOST_PTR)) == 0)
-        @warn("'hostbuf' was passed, but no memory flags to make use of it")
-    end
-
-    if flags == (CL_MEM_USE_HOST_PTR | CL_MEM_ALLOC_HOST_PTR)
-        ArgumentError("Use host pointer flag and alloc host pointer flag are mutually exclusive")
-    end
-
-    nbytes = 0
-    retain_buf::Union{Nothing,Array{T}} = nothing
-
-    if hostbuf !== nothing
-        if (flags & CL_MEM_USE_HOST_PTR) != 0
-            retain_buf = hostbuf
-        end
-        if len > length(hostbuf)
-            ArgumentError("OpenCL.Buffer specified size greater than host buffer size")
-        end
-        if len == 0
-            len = length(hostbuf)
-            nbytes = sizeof(hostbuf)
-        else
-            nbytes = len * sizeof(T)
-        end
+    if host == :rw
+        # nothing to do
+    elseif host == :r
+        flags |= CL_MEM_HOST_READ_ONLY
+    elseif host == :w
+        flags |= CL_MEM_HOST_WRITE_ONLY
+    elseif host == :none
+        flags |= CL_MEM_HOST_NO_ACCESS
     else
-        if len <= 0
-            ArgumentError("OpenCL.Buffer specified length is <= 0")
-        end
-        nbytes = len * sizeof(T)
+        throw(ArgumentError("Host access flag must be one of :rw, :r, or :w"))
     end
 
     err_code = Ref{Cint}()
-    mem_id = clCreateBuffer(context(), flags, cl_uint(nbytes),
-                            hostbuf !== nothing ? hostbuf : C_NULL,
-                            err_code)
+    mem_id = clCreateBuffer(context(), flags, sz, something(hostbuf, C_NULL), err_code)
     if err_code[] != CL_SUCCESS
         throw(CLError(err_code[]))
     end
-
-    try
-        return Buffer{T}(mem_id, false, len)
-    catch err
-        clReleaseMemObject(mem_id)
-        throw(err)
-    end
+    return Buffer{T}(mem_id, len)
 end
 
-# enqueue a read from buffer to hoast array from buffer, return an event
-function enqueue_read_buffer(buf::Buffer{T},
-                             hostbuf::Array{T},
-                             dev_offset::Csize_t,
-                             wait_for::Union{Nothing,Vector{Event}},
-                             is_blocking::Bool) where T
-    n_evts  = wait_for === nothing ? UInt(0) : length(wait_for)
-    evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
+# allocated buffer
+function Buffer{T}(len::Integer; host_accessible=false, kwargs...) where {T}
+    flags = host_accessible ? CL_MEM_ALLOC_HOST_PTR : 0
+    Buffer{T}(len, flags, nothing; kwargs...)
+end
+
+# from host memory
+function Buffer(hostbuf::Array{T}; copy::Bool=true, kwargs...) where {T}
+    flags = copy ? CL_MEM_COPY_HOST_PTR : CL_MEM_USE_HOST_PTR
+    Buffer{T}(length(hostbuf), flags, hostbuf; kwargs...)
+end
+
+
+## memory operations
+
+# reading from buffer to host array, return an event
+function Base.unsafe_copyto!(dst::Array{T}, dst_off::Int, src::Buffer{T}, src_off::Int,
+                             N::Int; blocking::Bool=false,
+                             wait_for::Vector{Event}=Event[]) where T
+    nbytes = N * sizeof(T)
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
     ret_evt = Ref{cl_event}()
-    nbytes  = sizeof(hostbuf)
-    @assert nbytes > 0
-    clEnqueueReadBuffer(queue(), buf, cl_bool(is_blocking),
-                        dev_offset, nbytes, hostbuf,
+    clEnqueueReadBuffer(queue(), src, blocking, src_off-1, nbytes, pointer(dst, dst_off),
                         n_evts, evt_ids, ret_evt)
-    @return_nanny_event(ret_evt[], hostbuf)
+    @return_nanny_event(ret_evt[], dst)
 end
+Base.unsafe_copyto!(dst::Array, src::Buffer, N; kwargs...) =
+    unsafe_copyto!(dst, 1, src, 1, N; kwargs...)
 
-# enqueue a write from host array to buffer, return an event
-function enqueue_write_buffer(buf::Buffer{T},
-                              hostbuf::Array{T},
-                              byte_count::Csize_t,
-                              offset::Csize_t,
-                              wait_for::Union{Nothing,Vector{Event}},
-                              is_blocking::Bool) where T
-    n_evts  = wait_for === nothing ? UInt(0) : length(wait_for)
-    evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
+# writing from host array to buffer, return an event
+function Base.unsafe_copyto!(dst::Buffer{T}, dst_off::Int, src::Array{T}, src_off::Int,
+                             N::Int; blocking::Bool=false,
+                             wait_for::Vector{Event}=Event[]) where T
+    nbytes = N * sizeof(T)
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
     ret_evt = Ref{cl_event}()
-    nbytes  = sizeof(hostbuf)
-    @assert nbytes > 0
-    clEnqueueWriteBuffer(queue(), buf, cl_bool(is_blocking),
-                         offset, nbytes, hostbuf,
+    clEnqueueWriteBuffer(queue(), dst, blocking, dst_off-1, nbytes, pointer(src, src_off),
                          n_evts, evt_ids, ret_evt)
-    @return_nanny_event(ret_evt[], hostbuf)
+    @return_nanny_event(ret_evt[], dst)
 end
+Base.unsafe_copyto!(dst::Buffer, src::Array, N; kwargs...) =
+    unsafe_copyto!(dst, 1, src, 1, N; kwargs...)
 
-# enqueue a copy from one buffer to another, return an event
-function enqueue_copy_buffer(src::Buffer{T},
-                             dst::Buffer{T},
-                             byte_count::Csize_t,
-                             src_offset::Csize_t,
-                             dst_offset::Csize_t,
-                             wait_for::Union{Nothing,Vector{Event}}) where T
-    n_evts  = wait_for === nothing ? UInt(0) : length(wait_for)
-    evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
+# copying between two buffers, return an event
+function Base.unsafe_copyto!(dst::Buffer{T}, dst_off::Int, src::Buffer{T}, src_off::Int,
+                             N::Int; blocking::Bool=false,
+                             wait_for::Vector{Event}=Event[]) where T
+    nbytes = N * sizeof(T)
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
     ret_evt = Ref{cl_event}()
-    if byte_count < 0
-        byte_count = min(sizeof(src), sizeof(dst))
-    end
-    @assert byte_count > 0
-    clEnqueueCopyBuffer(queue(), src, dst,
-                        src_offset, dst_offset, byte_count,
+    clEnqueueCopyBuffer(queue(), src, dst, src_off-1, dst_off-1, nbytes,
                         n_evts, evt_ids, ret_evt)
     @return_event ret_evt[]
 end
+Base.unsafe_copyto!(dst::Buffer, src::Buffer, N; kwargs...) =
+    unsafe_copyto!(dst, 1, src, 1, N; kwargs...)
 
-# return whether a given buffer is mapped
-ismapped(b::Buffer) = b.mapped
-
-# enqueue an unmap buffer op, return an event
-function enqueue_unmap_mem(b::Buffer{T},
-                           a::Array{T};
-                           wait_for=nothing) where T
-    if b.hostbuf != pointer(a)
-        throw(ArgumentError("array @$(pointer(a)) is not mapped to buffer $b"))
-    end
-    if b.mapped == false || b.hostbuf == C_NULL
-        throw(CLMemoryError("$b has already been unmapped"))
-    end
-    n_evts  = 0
-    evt_ids = C_NULL
-    if wait_for !== nothing
-        if isa(wait_for, Event)
-            n_evts = 1
-            evt_ids = [wait_for.id]
-        else
-            @assert all([isa(evt, Event) for evt in wait_for])
-            n_evts = length(wait_for)
-            evt_ids = [evt.id for evt in wait_for]
-        end
-    end
-    ret_evt = Ref{cl_event}()
-    clEnqueueUnmapMemObject(queue(), b, a, n_evts, evt_ids, ret_evt)
-    b.mapped  = false
-    b.hostbuf = C_NULL
-    @return_event ret_evt[]
-end
-
-# (blocking) unmap a given buffer/array
-function unmap!(b::Buffer{T}, a::Array{T}) where T
-    evt = enqueue_unmap_mem(b, a)
-    return wait(evt)
-end
-
-
-# enqueue a memory mapping operation, returning a mapped (pinned) Array and an event
-function enqueue_map_mem(b::Buffer{T},
-                         flags::Symbol,
-                         offset::Integer,
-                         dims::Dims,
-                         wait_for=nothing,
-                         is_blocking=false) where T
-    local f::cl_map_flags
-    if flags === :r
-        f = CL_MAP_READ
-    elseif flags === :w
-        f = CL_MAP_WRITE
-    elseif flags === :rw
-        f = CL_MAP_READ | CL_MAP_WRITE
-    else
-        throw(ArgumentError("enqueue_unmap can have flags of :r, :w, or :rw, got :$flags"))
-    end
-    return enqueue_map_mem(b, f, offset, dims, wait_for, is_blocking)
-end
-
-# enqueue a memory mapping operation, returning a mapped (pinned) Array and an event
-function enqueue_map_mem(b::Buffer{T},
-                         flags::cl_map_flags,
-                         offset::Integer,
-                         dims::Dims,
-                         wait_for=nothing,
-                         is_blocking=false) where T
+# map a a buffer into the host address space and return a (pinned) array and an event
+function unsafe_map!(b::Buffer{T}, dims::Dims, flags=:rw; offset::Integer=0,
+                     blocking::Bool=false, wait_for::Vector{Event}=Event[]) where {T}
     if length(b) < prod(dims) + offset
         throw(ArgumentError("Buffer length must be greater than or
                              equal to prod(dims) + offset"))
     end
-    n_evts  = wait_for === nothing ? cl_uint(0) : cl_uint(length(wait_for))
-    evt_ids = wait_for === nothing ? C_NULL  : [evt.id for evt in wait_for]
-    flags   = cl_map_flags(flags)
-    offset  = unsigned(offset)
-    nbytes  = unsigned(prod(dims) * sizeof(T))
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
+    flags = if flags == :rw
+        CL_MAP_READ | CL_MAP_WRITE
+    elseif flags == :r
+        CL_MAP_READ
+    elseif flags == :w
+        CL_MAP_WRITE
+    else
+        throw(ArgumentError("enqueue_unmap can have flags of :r, :w, or :rw, got :$flags"))
+    end
+    nbytes  = prod(dims) * sizeof(T)
     ret_evt = Ref{cl_event}()
     status  = Ref{Cint}()
-    mapped  = clEnqueueMapBuffer(queue(), b, cl_bool(is_blocking ? 1 : 0),
+    mapped  = clEnqueueMapBuffer(queue(), b, blocking,
                                  flags, offset, nbytes,
                                  n_evts, evt_ids, ret_evt, status)
     if status[] != CL_SUCCESS
         throw(CLError(status[]))
     end
-    mapped = Base.unsafe_convert(Ptr{T}, mapped)
-    N = length(dims)
-    local mapped_arr::Array{T, N}
-    try
-        # julia owns pointer to mapped memory
-        mapped_arr = unsafe_wrap(Array{T, N}, mapped, dims, own=false)
-        # when array is gc'd, unmap buffer
-        b.mapped  = true
-        b.hostbuf = mapped
-        finalizer(mapped_arr) do x
-            if b.mapped && b.hostbuf != C_NULL
-                unmap!(queue(), b, x)
-            end
-        end
-    catch err
-        clEnqueueUnmapMemObject(queue(), b, mapped, unsigned(0), C_NULL, C_NULL)
-        b.mapped  = false
-        b.hostbuf = C_NULL
-        rethrow(err)
-    end
-    return (mapped_arr, Event(ret_evt[]))
+
+    return unsafe_wrap(Array, Ptr{T}(mapped), dims; own=false), Event(ret_evt[])
 end
 
-# low level enqueue fill operation, return event
-function enqueue_fill_buffer(buf::Buffer{T},
-                             pattern::T, offset::Csize_t,
-                             nbytes::Csize_t,
-                             wait_for::Union{Vector{Event},Nothing}) where T
-    if wait_for === nothing
-        evt_ids = C_NULL
-        n_evts = cl_uint(0)
-    else
-        evt_ids = [evt.id for evt in wait_for]
-        n_evts  = cl_uint(length(evt_ids))
-    end
+# unmap a buffer, return an event
+function unsafe_unmap!(b::Buffer{T}, a::Array{T}; wait_for::Vector{Event}=Event[]) where {T}
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
     ret_evt = Ref{cl_event}()
-    nbytes_pattern = sizeof(pattern)
+    clEnqueueUnmapMemObject(queue(), b, a, n_evts, evt_ids, ret_evt)
+    return Event(ret_evt[])
+end
+
+# fill a buffer with a pattern, returning an event
+function unsafe_fill!(b::Buffer{T}, pattern::T, offset::Integer, N::Integer;
+                      wait_for::Vector{Event}=Event[]) where {T}
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
+    ret_evt = Ref{cl_event}()
+    nbytes = N * sizeof(T)
+    nbytes_pattern = sizeof(T)
     @assert nbytes_pattern > 0
-    clEnqueueFillBuffer(queue(), buf, [pattern],
-                        unsigned(nbytes_pattern), offset, nbytes,
+    clEnqueueFillBuffer(queue(), b, [pattern],
+                        nbytes_pattern, offset, nbytes,
                         n_evts, evt_ids, ret_evt)
     @return_event ret_evt[]
 end
-
-# enqueue a fill operation, return an event
-function enqueue_fill(buf::Buffer{T}, x::T) where T
-    nbytes = sizeof(buf)
-    evt = enqueue_fill_buffer(buf, x, unsigned(0), unsigned(nbytes), nothing)
-    return evt
-end
-
-# (blocking) fill the contents of a buffer with with a given value
-function fill!(buf::Buffer{T}, x::T) where T
-    evt = enqueue_fill(buf, x)
-    wait(evt)
-    return evt
-end
-
-# copy the contents of a buffer into an array
-function Base.copy!(dst::Array{T}, src::Buffer{T}) where T
-    if sizeof(dst) != sizeof(src)
-        throw(ArgumentError("Buffer and Array to be copied must be the same size"))
-    end
-    evt = enqueue_read_buffer(src, dst, UInt(0), nothing, true)
-    return evt
-end
-
-# copy the contents of an array into a buffer
-function Base.copy!(dst::Buffer{T}, src::Array{T}) where T
-    if sizeof(dst) != sizeof(src)
-        throw(ArgumentError("Array and Buffer to be copied must be the same size"))
-    end
-    nbytes = convert(Csize_t, sizeof(src))
-    evt = enqueue_write_buffer(dst, src, nbytes, unsigned(0), nothing, true)
-    return evt
-end
-
-# copy the contents of a buffer into another buffer
-function Base.copy!(dst::Buffer{T}, src::Buffer{T}) where T
-    if sizeof(dst) != sizeof(src)
-        throw(ArgumentError("Buffers to be copied must be the same size"))
-    end
-    nbytes = convert(Csize_t, sizeof(src))
-    evt = enqueue_copy_buffer(src, dst, nbytes, unsigned(0),
-                              unsigned(0), nothing)
-    wait(evt)
-    return evt
-end
-
-# copy bufer into identical buffer object
-function Base.copy(src::Buffer{T}) where T
-    nbytes = sizeof(src)
-    new_buff = empty_like(src)
-    copy!(new_buff, src)
-    return new_buff
-end
-
-# create an empty buffer similar to the passed in buffer
-function empty_like(b::Buffer{T}) where T
-    len = length(b)
-    mf = b.mem_flags
-    if :r in mf
-        return Buffer(T, len, :r)
-    elseif :w in mf
-        return Buffer(T, len, :w)
-    else
-        return Buffer(T, len, :rw)
-    end
-end
-
-# create an empty buffer similar to the passed in Array
-function empty_like(a::Array{T}, flag::Symbol=:rw) where T
-    len = length(a)
-    return Buffer(T, len, flag)
-end
-
-# blocking write of contents of an array to a buffer
-function write!(buf::Buffer{T}, hostbuf::Array{T}) where T
-    nbytes = unsigned(sizeof(hostbuf))
-    enqueue_write_buffer(buf, hostbuf, nbytes, unsigned(0), nothing, true)
-    return
-end
-
-# blocking read of the contents of a buffer into a new array
-function read(buf::Buffer{T}) where T
-    hostbuf = Vector{T}(undef, length(buf))
-    enqueue_read_buffer(buf, hostbuf, unsigned(0), nothing, true)
-    return hostbuf
-end
+unsafe_fill!(b::Buffer, pattern, N::Integer) = unsafe_fill!(b, pattern, 0, N)

--- a/lib/kernel.jl
+++ b/lib/kernel.jl
@@ -70,7 +70,7 @@ function set_arg!(k::Kernel, idx::Integer, arg::Ptr{Nothing})
     set_arg!(k, idx, nothing)
 end
 
-function set_arg!(k::Kernel, idx::Integer, arg::CLMemObject)
+function set_arg!(k::Kernel, idx::Integer, arg::AbstractMemory)
     arg_boxed = Ref(arg.id)
     clSetKernelArg(k, cl_uint(idx-1), sizeof(cl_mem), arg_boxed)
     return k

--- a/lib/kernel.jl
+++ b/lib/kernel.jl
@@ -71,20 +71,17 @@ function set_arg!(k::Kernel, idx::Integer, arg::Ptr{Nothing})
 end
 
 function set_arg!(k::Kernel, idx::Integer, arg::CLMemObject)
-    @assert idx > 0
-    arg_boxed = Ref{typeof(arg.id)}(arg.id)
+    arg_boxed = Ref(arg.id)
     clSetKernelArg(k, cl_uint(idx-1), sizeof(cl_mem), arg_boxed)
     return k
 end
 
 function set_arg!(k::Kernel, idx::Integer, arg::LocalMem)
-    @assert idx > 0 "Kernel idx must be bigger 0"
     clSetKernelArg(k, cl_uint(idx-1), arg.nbytes, C_NULL)
     return k
 end
 
 function set_arg!(k::Kernel, idx::Integer, arg::T) where T
-    @assert idx > 0 "Kernel idx must be bigger 0"
     ref = Ref(arg)
     tsize = sizeof(ref)
     err = unchecked_clSetKernelArg(k, cl_uint(idx - 1), tsize, ref)

--- a/lib/memory.jl
+++ b/lib/memory.jl
@@ -1,34 +1,29 @@
 # OpenCL Memory Object
 
-abstract type CLMemObject <: CLObject end
+abstract type AbstractMemory <: CLObject end
 
 #This should be implemented by all subtypes
-# type CLMemType <: CLMemObject
-#     valid::Bool
+# type MemoryType <: AbstractMemory
 #     id::cl_mem
 #     ...
 # end
 
-Base.unsafe_convert(::Type{cl_mem}, mem::CLMemObject) = mem.id
+Base.unsafe_convert(::Type{cl_mem}, mem::AbstractMemory) = mem.id
 
-Base.pointer(mem::CLMemObject) = mem.id
+Base.pointer(mem::AbstractMemory) = mem.id
 
-Base.sizeof(mem::CLMemObject) = mem.size
+Base.sizeof(mem::AbstractMemory) = mem.size
 
-function _finalize(mem::CLMemObject)
-    if !mem.valid
-        throw(CLMemoryError("attempted to double free mem object $mem"))
-    end
+function _finalize(mem::AbstractMemory)
     if mem.id != C_NULL
         clReleaseMemObject(mem.id)
         mem.id = C_NULL
     end
-    mem.valid = false
 end
 
-context(mem::CLMemObject) = mem.context
+context(mem::AbstractMemory) = mem.context
 
-function Base.getproperty(mem::CLMemObject, s::Symbol)
+function Base.getproperty(mem::AbstractMemory, s::Symbol)
     if s == :context
         param = Ref{cl_context}()
         clGetMemObjectInfo(mem, CL_MEM_CONTEXT, sizeof(cl_context), param, C_NULL)

--- a/src/array.jl
+++ b/src/array.jl
@@ -40,13 +40,7 @@ end
 Create in device memory array of type `t` and size `dims` filled by value `x`.
 """
 function fill(::Type{T}, x::T, dims...) where T
-    v = opencl_version(cl.context())
-    if v.major == 1 && v.minor >= 2
-        buf = cl.Buffer(T, prod(dims))
-        fill!(q, buf, x)
-    else
-        buf = cl.Buffer(T, prod(dims), (:rw, :copy), hostbuf=Base.fill(x, dims))
-    end
+    buf = cl.Buffer(T, prod(dims), (:rw, :copy), hostbuf=Base.fill(x, dims))
     return CLArray(buf, dims)
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -1,56 +1,63 @@
 import LinearAlgebra
 
-export CLArray, CLMatrix, CLVector
+export CLArray, CLMatrix, CLVector, buffer
 
-mutable struct CLArray{T, N} <: CLObject
+mutable struct CLArray{T, N} <: AbstractArray{T, N}
     ctx::cl.Context
     buffer::cl.Buffer{T}
     size::NTuple{N, Int}
+
+    function CLArray{T,N}(::UndefInitializer, dims::Dims{N};
+                          host=:rw, device=:rw) where {T,N}
+        buf = cl.Buffer{T}(prod(dims); host, device)
+        new(cl.context(), buf, dims)
+    end
+
+    function CLArray{T,N}(buf::cl.Buffer, dims::Dims) where {T,N}
+        new(cl.context(), buf, dims)
+    end
 end
+
+
+## convenience constructors
 
 const CLMatrix{T} = CLArray{T,2}
 const CLVector{T} = CLArray{T,1}
 
-## constructors
+# type and dimensionality specified
+CLArray{T,N}(::UndefInitializer, dims::NTuple{N,Integer}; kwargs...) where {T,N} =
+  CLArray{T,N}(undef, convert(Tuple{Vararg{Int}}, dims); kwargs...)
+CLArray{T,N}(::UndefInitializer, dims::Vararg{Integer,N}; kwargs...) where {T,N} =
+  CLArray{T,N}(undef, convert(Tuple{Vararg{Int}}, dims); kwargs...)
 
-function CLArray(buf::cl.Buffer{T}, sz::Tuple{Vararg{Int}}) where T
-    CLArray(cl.context(), buf, sz)
+# type but not dimensionality specified
+CLArray{T}(::UndefInitializer, dims::NTuple{N,Integer}; kwargs...) where {T,N} =
+  CLArray{T,N}(undef, convert(Tuple{Vararg{Int}}, dims); kwargs...)
+CLArray{T}(::UndefInitializer, dims::Vararg{Integer,N}; kwargs...) where {T,N} =
+  CLArray{T,N}(undef, convert(Tuple{Vararg{Int}}, dims); kwargs...)
+
+# empty vector constructor
+CLArray{T,1}() where {T} = CLArray{T,1}(undef, 0)
+
+Base.similar(a::CLArray{T,N}; kwargs...) where {T,N} =
+  CLArray{T,N}(undef, size(a); kwargs...)
+Base.similar(a::CLArray{T}, dims::Base.Dims{N}; kwargs...) where {T,N} =
+  CLArray{T,N}(undef, dims; kwargs...)
+Base.similar(a::CLArray, ::Type{T}, dims::Base.Dims{N}; kwargs...) where {T,N} =
+  CLArray{T,N}(undef, dims; kwargs...)
+
+function Base.copy(a::CLArray{T,N}; kwargs...) where {T,N}
+  b = similar(a; kwargs...)
+  @inbounds copyto!(b, a)
 end
 
-function CLArray(flags::Tuple{Vararg{Symbol}},
-                 hostarray::AbstractArray{T,N}) where {T, N}
-    buf = cl.Buffer(T, length(hostarray), flags, hostbuf=hostarray)
-    sz = size(hostarray)
-    CLArray(cl.context(), buf, sz)
+function Base.deepcopy_internal(x::CLArray, dict::IdDict)
+  haskey(dict, x) && return dict[x]::typeof(x)
+  return dict[x] = copy(x)
 end
 
-CLArray(hostarray::AbstractArray{T,N};
-        flags=(:rw, :copy)) where {T, N} = CLArray((:rw, :copy), hostarray)
 
-Base.copy(A::CLArray; ctx=A.ctx,
-          buffer=A.buffer, size=A.size) = CLArray(ctx, buffer, size)
-
-function Base.deepcopy(A::CLArray{T,N}) where {T, N}
-    new_buf = cl.Buffer(T, A.ctx, prod(A.size))
-    copy!(new_buf, A.buffer)
-    return CLArray(A.ctx, new_buf, A.size)
-end
-
-"""
-Create in device memory array of type `t` and size `dims` filled by value `x`.
-"""
-function fill(::Type{T}, x::T, dims...) where T
-    buf = cl.Buffer(T, prod(dims), (:rw, :copy), hostbuf=Base.fill(x, dims))
-    return CLArray(buf, dims)
-end
-
-zeros(::Type{T}, dims...) where {T} = fill(T, T(0), dims...)
-zeros(dims...) = fill(Float64, Float64(0), dims...)
-ones(::Type{T}, dims...) where {T} = fill(T, T(1), dims...)
-ones(dims...) = fill(Float64, Float64(1), dims...)
-
-
-## core functions
+## array interface
 
 buffer(A::CLArray) = A.buffer
 Base.pointer(A::CLArray) = A.buffer.id
@@ -62,21 +69,103 @@ Base.ndims(A::CLArray) = length(size(A))
 Base.length(A::CLArray) = prod(size(A))
 Base.:(==)(A:: CLArray, B:: CLArray) = buffer(A) == buffer(B) && size(A) == size(B)
 
-function Base.reshape(A::CLArray, dims...)
+function Base.reshape(A::CLArray{T}, dims::NTuple{N,Int}) where {T,N}
     @assert prod(dims) == prod(size(A))
-    return copy(A, size=dims)
+    CLArray{T,N}(buffer(A), dims)
+end
+
+
+## interop with other arrays
+
+function CLArray(hostarray::AbstractArray{T,N}; kwargs...) where {T, N}
+    buf = cl.Buffer(hostarray; kwargs...)
+    sz = size(hostarray)
+    CLArray{T,N}(buf, sz)
 end
 
 function Base.Array(A::CLArray{T,N}) where {T, N}
     hA = Array{T}(undef, size(A)...)
-    copy!(hA, buffer(A))
+    copyto!(hA, A)
     return hA
 end
+
+
+## utilities
+
+"""
+Create in device memory array of type `t` and size `dims` filled by value `x`.
+"""
+function fill(x::T, dims) where T
+    A = CLArray{T}(undef, dims)
+    fill!(A, x)
+end
+fill(x, dims...) = fill(x, (dims...,))
+
+function Base.fill!(A::CLArray{T}, x::T) where {T}
+    cl.unsafe_fill!(buffer(A), x, length(A))
+    A
+end
+
+zeros(::Type{T}, dims...) where {T} = fill(zero(T), dims...)
+zeros(dims...) = fill(Float64(0), dims...)
+ones(::Type{T}, dims...) where {T} = fill(one(T), dims...)
+ones(dims...) = fill(Float64(1), dims...)
+
+
+## memory copying
+
+typetagdata(a::Array, i=1) = ccall(:jl_array_typetagdata, Ptr{UInt8}, (Any,), a) + i - 1
+typetagdata(a::CLArray, i=1) =
+  convert(ZePtr{UInt8}, a.data[]) + a.maxsize + a.offset + i - 1
+
+function Base.copyto!(dest::CLArray{T}, doffs::Int, src::Array{T}, soffs::Int,
+                      n::Int) where T
+  n==0 && return dest
+  @boundscheck checkbounds(dest, doffs)
+  @boundscheck checkbounds(dest, doffs+n-1)
+  @boundscheck checkbounds(src, soffs)
+  @boundscheck checkbounds(src, soffs+n-1)
+  unsafe_copyto!(buffer(dest), doffs, src, soffs, n)
+  return dest
+end
+
+Base.copyto!(dest::CLArray{T}, src::Array{T}) where {T} =
+    copyto!(dest, 1, src, 1, length(src))
+
+function Base.copyto!(dest::Array{T}, doffs::Int, src::CLArray{T}, soffs::Int,
+                      n::Int) where T
+  n==0 && return dest
+  @boundscheck checkbounds(dest, doffs)
+  @boundscheck checkbounds(dest, doffs+n-1)
+  @boundscheck checkbounds(src, soffs)
+  @boundscheck checkbounds(src, soffs+n-1)
+  unsafe_copyto!(dest, doffs, buffer(src), soffs, n; blocking=true)
+  return dest
+end
+Base.copyto!(dest::Array{T}, src::CLArray{T}) where {T} =
+    copyto!(dest, 1, src, 1, length(src))
+
+function Base.copyto!(dest::CLArray{T}, doffs::Int, src::CLArray{T}, soffs::Int,
+                      n::Int) where T
+  n==0 && return dest
+  @boundscheck checkbounds(dest, doffs)
+  @boundscheck checkbounds(dest, doffs+n-1)
+  @boundscheck checkbounds(src, soffs)
+  @boundscheck checkbounds(src, soffs+n-1)
+  @assert context(dest) == context(src)
+  unsafe_copyto!(buffer(dest), doffs, buffer(src), soffs, n)
+  return dest
+end
+
+Base.copyto!(dest::CLArray{T}, src::CLArray{T}) where {T} =
+    copyto!(dest, 1, src, 1, length(src))
+
 
 ## show
 
 Base.show(io::IO, A::CLArray{T,N}) where {T, N} =
     print(io, "CLArray{$T,$N}($(buffer(A)),$(size(A)))")
+
 
 ## other array operations
 
@@ -129,6 +218,6 @@ end
 function LinearAlgebra.transpose(A::CLMatrix{Float64})
     B = zeros(Float64, reverse(size(A))...)
     ev = LinearAlgebra.transpose!(B, A)
-    cl.wait(ev)
+    wait(ev)
     return B
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -1,18 +1,3 @@
-export opencl_version
-
-function parse_version(version_string)
-    mg = match(r"^OpenCL ([0-9]+)\.([0-9]+) .*$", version_string)
-    if mg === nothing
-        error("Non conforming version string: $(ver)")
-    end
-    return VersionNumber(parse(Int, mg.captures[1]),
-                                 parse(Int, mg.captures[2]))
-end
-
-opencl_version(obj::CLObject) = parse_version(obj.version)
-opencl_version(c::cl.Context)  = opencl_version(first(c.devices))
-opencl_version(q::cl.CmdQueue) = opencl_version(q.device)
-
 """
 Format string using dict-like variables, replacing all accurancies of
 `%(key)` with `value`.
@@ -70,7 +55,12 @@ function versioninfo(io::IO=stdout)
     println(io, "Available platforms: ", length(cl.platforms()))
     for platform in cl.platforms()
         println(io, " - $(platform.name)")
-        println(io, "   version: $(platform.version)")
+        print(io, "   OpenCL $(platform.opencl_version.major).$(platform.opencl_version.minor)")
+        if !isempty(platform.version)
+            print(io, ", $(platform.version)")
+        end
+        println(io)
+
         for device in cl.devices(platform)
             print(io, "   · $(device.name)")
 

--- a/test/array.jl
+++ b/test/array.jl
@@ -2,24 +2,32 @@ using LinearAlgebra
 
 @testset "CLArray" begin
     @testset "constructors" begin
-        hostarray = zeros(Float32, 128*64)
+        @test CLArray{Float32,1}(undef, 1) isa CLArray{Float32,1}
+        @test CLArray{Float32,1}(undef, 1; device=:r) isa CLArray{Float32,1}
+        @test CLArray{Float32,1}(undef, 1; host=:r) isa CLArray{Float32,1}
+
+        @test CLArray{Float32}(undef, 1, 2) isa CLArray{Float32,2}
+        @test CLArray{Float32}(undef, 1, 2; device=:r) isa CLArray{Float32,2}
+        @test CLArray{Float32}(undef, 1, 2; host=:r) isa CLArray{Float32,2}
+
+        @test CLArray{Float32}(undef, (1, 2)) isa CLArray{Float32,2}
+        @test CLArray{Float32}(undef, (1, 2); device=:r) isa CLArray{Float32,2}
+        @test CLArray{Float32}(undef, (1, 2); host=:r) isa CLArray{Float32,2}
+
+        hostarray = rand(Float32, 128*64)
         A = CLArray(hostarray)
+        @test A isa CLArray{Float32,1}
+        @test Array(A) == hostarray
 
-        @test CLArray((:rw, :copy), hostarray) != nothing
+        B = CLArray(hostarray; device=:r, host=:rw)
+        @test B isa CLArray{Float32,1}
+        @test Array(B) == hostarray
 
-        @test CLArray(hostarray, flags=(:rw, :copy)) != nothing
-
-        @test CLArray(hostarray) != nothing
-
-        @test CLArray(cl.Buffer(Float32, length(hostarray), (:r, :copy), hostbuf=hostarray),
-                      (128, 64)) != nothing
-
-        @test copy(A) == A
+        @test Array(copy(A)) == Array(A)
     end
 
     @testset "fill" begin
-        @test Array(OpenCL.fill(Float32, Float32(0.5),
-                                32, 64)) == fill(Float32(0.5), 32, 64)
+        @test Array(OpenCL.fill(Float32(0.5), 32, 64)) == fill(Float32(0.5), 32, 64)
         @test Array(OpenCL.zeros(Float32, 64)) == zeros(Float32, 64)
         @test Array(OpenCL.ones(Float32, 64)) == ones(Float32, 64)
     end

--- a/test/buffer.jl
+++ b/test/buffer.jl
@@ -1,200 +1,62 @@
 @testset "Buffer" begin
-    @testset "constructors" begin
-        testarray = zeros(Float32, 1000)
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_ALLOC_HOST_PTR | cl.CL_MEM_READ_ONLY) != nothing
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_ALLOC_HOST_PTR | cl.CL_MEM_WRITE_ONLY) != nothing
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_ALLOC_HOST_PTR | cl.CL_MEM_READ_WRITE) != nothing
-
-        buf = cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_ALLOC_HOST_PTR | cl.CL_MEM_READ_WRITE)
-        @test length(buf) == length(testarray)
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_COPY_HOST_PTR | cl.CL_MEM_READ_ONLY;
-                        hostbuf=testarray) != nothing
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_COPY_HOST_PTR | cl.CL_MEM_WRITE_ONLY;
-                        hostbuf=testarray) != nothing
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_COPY_HOST_PTR | cl.CL_MEM_READ_WRITE;
-                        hostbuf=testarray) != nothing
-
-        buf = cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_COPY_HOST_PTR | cl.CL_MEM_READ_WRITE;
-                        hostbuf=testarray)
-        @test length(buf) == length(testarray)
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_READ_ONLY;
-                        hostbuf=testarray) != nothing
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_WRITE_ONLY;
-                        hostbuf=testarray) != nothing
-
-        @test cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_READ_WRITE;
-                        hostbuf=testarray) != nothing
-
-        buf = cl.Buffer(Float32, length(testarray),
-                        cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_READ_WRITE;
-                        hostbuf=testarray)
-        @test length(buf) == length(testarray)
-
-        # invalid buffer size should throw error
-        @test_throws cl.CLError cl.Buffer(Float32, +0, cl.CL_MEM_ALLOC_HOST_PTR)
-        @test_throws InexactError cl.Buffer(Float32, -1, cl.CL_MEM_ALLOC_HOST_PTR)
-
-        # invalid flag combinations should throw error
-        @test_throws cl.CLError cl.Buffer(Float32, length(testarray),
-                                          cl.CL_MEM_USE_HOST_PTR | cl.CL_MEM_ALLOC_HOST_PTR;
-                                          hostbuf=testarray)
-
-        # invalid host pointer should throw error
-        @test_throws TypeError cl.Buffer(Float32, 1, cl.CL_MEM_COPY_HOST_PTR;
-                                         hostbuf=C_NULL)
-
-        @test_throws TypeError cl.Buffer(Float32, 1, cl.CL_MEM_USE_HOST_PTR,
-                                         hostbuf=C_NULL)
-     end
-
-     @testset "constructors symbols" begin
-         for mf1 in [:rw, :r, :w]
-             for mf2 in [:copy, :use, :alloc, :null]
-                 for mtype in [cl.Cchar,
-                               cl.Cuchar,
-                               cl.Cshort,
-                               cl.Cushort,
-                               Cint,
-                               cl.Cuint,
-                               cl.Clong,
-                               cl.Culong,
-                               Float16,
-                               Cfloat,
-                               Cdouble,
-                               #TODO: bool, vector_types, struct_types...
-                               ]
-                     testarray = zeros(mtype, 100)
-                     if mf2 == :copy || mf2 == :use
-                         @test cl.Buffer(mtype, length(testarray), (mf1, mf2);
-                                         hostbuf=testarray) != nothing
-                         buf = cl.Buffer(mtype, length(testarray), (mf1, mf2);
-                                         hostbuf=testarray)
-                         @test length(buf) == length(testarray)
-                     elseif mf2 == :alloc
-                         @test cl.Buffer(mtype, length(testarray),
-                                         (mf1, mf2)) != nothing
-                         buf = cl.Buffer(mtype, length(testarray), (mf1, mf2))
-                         @test length(buf) == length(testarray)
-                     end
-                 end
-             end
-         end
-
-        TestStruct = @eval(module $(gensym("KernelTest"))
-                struct TestStruct
-                    a::Cint
-                    b::Cfloat
-                end
-            end).TestStruct
-
-         test_array = Vector{TestStruct}(undef, 100)
-         @test cl.Buffer(TestStruct, length(test_array), :alloc) != nothing
-         @test cl.Buffer(TestStruct, length(test_array), :copy;
-                         hostbuf=test_array) != nothing
-
-         # invalid buffer size should throw error
-         @test_throws cl.CLError cl.Buffer(Float32, +0, :alloc)
-         @test_throws InexactError cl.Buffer(Float32, -1, :alloc)
-
-         # invalid flag combinations should throw error
-         @test_throws ArgumentError cl.Buffer(Float32, length(test_array),
-                                              (:use, :alloc), hostbuf=test_array)
-
-         # invalid host pointer should throw error
-         @test_throws TypeError cl.Buffer(Float32, 1, :copy, hostbuf=C_NULL)
-
-         @test_throws TypeError cl.Buffer(Float32, 1, :use, hostbuf=C_NULL)
-     end
-
-    @testset "fill" begin
-        testarray = zeros(Float32, 1000)
-        buf = cl.Buffer(Float32, length(testarray), (:rw, :copy), hostbuf=testarray)
-        @test length(buf) == length(testarray)
-
-        cl.fill!(buf, 1f0)
-        readback = cl.read(buf)
-        @test all(x -> x == 1.0, readback)
-        @test all(x -> x == 0.0, testarray)
-        @test buf.valid == true
+    # simple buffer
+    let buf = cl.Buffer{Int}(1)
+        @test ndims(buf) == 1
+        @test eltype(buf) == Int
+        @test length(buf) == 1
+        @test sizeof(buf) == sizeof(Int)
     end
 
-    @testset "write!" begin
-        testarray = zeros(Float32, 1000)
-        buf = cl.Buffer(Float32, length(testarray), (:rw, :copy); hostbuf=testarray)
-        @test length(buf) == length(testarray)
-        cl.write!(buf, ones(Float32, length(testarray)))
-        readback = cl.read(buf)
-        @test all(x -> x == 1.0, readback) == true
-        @test buf.valid == true
+    # host accessible, mapped
+    let buf = cl.Buffer{Int}(1; host_accessible=true)
+        unsafe_copyto!(buf, [42], 1; blocking=true)
+
+        arr, evt = cl.unsafe_map!(buf, (1,), :rw)
+        wait(evt)
+        @test arr[] == 42
+        cl.unsafe_unmap!(buf, arr)
     end
 
-    @testset "empty_like" begin
-        testarray = zeros(Float32, 1000)
-        buf = cl.Buffer(Float32, length(testarray), (:rw, :copy); hostbuf=testarray)
+    # re-use host buffer, without copy
+    let arr = [1,2,3]
+        buf = cl.Buffer(arr; copy=false)
 
-        @test sizeof(cl.empty_like(buf)) == sizeof(testarray)
+        dst = similar(arr)
+        unsafe_copyto!(dst, buf, 3; blocking=true)
+        @test dst == arr
+
+        # we still need to map, despite copy=false
+        mapped_arr, evt = cl.unsafe_map!(buf, (3,), :rw)
+        wait(evt)
+        mapped_arr .= 42
+        cl.unsafe_unmap!(buf, mapped_arr) |> wait
+
+        # but our pre-allocated buffer should have been updated too
+        @test arr == [42,42,42]
+
+        unsafe_copyto!(dst, buf, 3; blocking=true)
+        @test dst == arr
     end
 
-    @testset "copy!" begin
-        test_array = fill(2f0, 1000)
-        a_buf = cl.Buffer(Float32, length(test_array))
-        b_buf = cl.Buffer(Float32, length(test_array))
-        c_arr = Vector{Float32}(undef, length(test_array))
-        # host to device buffer
-        cl.copy!(a_buf, test_array)
-        # device buffer to device buffer
-        cl.copy!(b_buf, a_buf)
-        # device buffer to host
-        cl.copy!(c_arr, b_buf)
-        @test all(x -> isapprox(x, 2.0), c_arr) == true
+    # re-use host buffer, but copy
+    let arr = [1,2,3]
+        buf = cl.Buffer(arr; copy=true)
+
+        dst = similar(arr)
+        unsafe_copyto!(dst, buf, 3; blocking=true)
+        @test dst == arr
+
+        arr .= 42
+
+        unsafe_copyto!(dst, buf, 3; blocking=true)
+        @test dst == [1,2,3]
     end
 
-    @testset "map/unmap" begin
-        b = cl.Buffer(Float32, 100, :rw)
-        for f in (:r, :w, :rw)
-            a, evt = cl.enqueue_map_mem(b, f, 0, (10,10))
-            cl.wait(evt)
-            @test size(a) == (10,10)
-            @test typeof(a) == Array{Float32,2}
-
-            # cannot unmap a buffer without same host array
-            bad = similar(a)
-            @test_throws ArgumentError cl.unmap!(b, bad)
-
-            @test cl.ismapped(b) == true
-            cl.unmap!(b, a)
-            @test cl.ismapped(b) == false
-
-            # cannot unmap an unmapped buffer
-            @test_throws ArgumentError cl.unmap!(b, a)
-
-            # gc here quickly force any memory errors
-            GC.gc()
-        end
-        @test cl.ismapped(b) == false
-        a, evt = cl.enqueue_map_mem(b, :rw, 0, (10,10))
-        @test cl.ismapped(b) == true
-        evt = cl.enqueue_unmap_mem(b, a, wait_for=evt)
-        cl.wait(evt)
-        @test cl.ismapped(b) == false
+    # fill
+    let buf = cl.Buffer{Int}(3)
+        cl.unsafe_fill!(buf, 42, 3)
+        arr = Vector{Int}(undef, 3)
+        unsafe_copyto!(arr, buf, 3; blocking=true)
+        @test arr == [42,42,42]
     end
 end

--- a/test/device.jl
+++ b/test/device.jl
@@ -36,10 +36,6 @@
                 :name,
                 :device_type,
                 :has_image_support,
-                :queue_properties,
-                :has_queue_out_of_order_exec,
-                :has_queue_profiling,
-                :has_native_kernel,
                 :vendor_id,
                 :max_compute_units,
                 :max_work_item_size,
@@ -84,5 +80,12 @@
                 @test length(v) == 3
             end
         end
+
+        @test cl.queue_properties(cl.device()).profiling isa Bool
+        @test cl.queue_properties(cl.device()).out_of_order_exec isa Bool
+
+        @test cl.exec_capabilities(cl.device()).native_kernel isa Bool
+
+        @test cl.svm_capabilities(cl.device()).fine_grain_buffer isa Bool
     end
 end

--- a/test/event.jl
+++ b/test/event.jl
@@ -27,7 +27,7 @@ else
         cl.complete(usr_evt)
         @test usr_evt.status == :complete
 
-        cl.wait(mkr_evt)
+        wait(mkr_evt)
         @test mkr_evt.status == :complete
 
         @test cl.cl_event_status(:running) == cl.CL_RUNNING
@@ -57,7 +57,7 @@ else
         cl.complete(usr_evt)
         @test usr_evt.status == :complete
 
-        cl.wait(mkr_evt)
+        wait(mkr_evt)
 
         # Give callback some time to finish
         yield()

--- a/test/kernel.jl
+++ b/test/kernel.jl
@@ -51,45 +51,37 @@
 
         h_ones = ones(Float32, count)
 
-        A = cl.Buffer(Float32, length(h_ones), (:r, :copy), hostbuf=h_ones)
-        B = cl.Buffer(Float32, length(h_ones), (:r, :copy), hostbuf=h_ones)
-        C = cl.Buffer(Float32, count, :w)
-
-        # sizeof mem object for buffer in bytes
-        @test sizeof(A) == nbytes
-        @test sizeof(B) == nbytes
-        @test sizeof(C) == nbytes
+        A = CLArray(h_ones; device=:r)
+        B = CLArray(h_ones; device=:r)
+        C = CLArray{Float32}(undef, count; device=:w)
 
         # we use julia's index by one convention
-        @test cl.set_arg!(k, 1, A) != nothing
-        @test cl.set_arg!(k, 2, B) != nothing
-        @test cl.set_arg!(k, 3, C) != nothing
+        @test cl.set_arg!(k, 1, buffer(A)) != nothing
+        @test cl.set_arg!(k, 2, buffer(B)) != nothing
+        @test cl.set_arg!(k, 3, buffer(C)) != nothing
         @test cl.set_arg!(k, 4, UInt32(count)) != nothing
 
-        cl.enqueue_kernel(k, count) |> cl.wait
-        r = cl.read(C)
+        cl.enqueue_kernel(k, count) |> wait
+        r = Array(C)
 
         @test all(x -> x == 2.0, r)
         cl.flush(cl.queue())
 
         # test set_args with new kernel
         k2 = cl.Kernel(prg, "sum")
-        cl.set_args!(k2, A, B, C, UInt32(count))
+        cl.set_args!(k2, buffer(A), buffer(B), buffer(C), UInt32(count))
 
         h_twos = fill(2f0, count)
-        cl.copy!(A, h_twos)
-        cl.copy!(B, h_twos)
+        copyto!(A, h_twos)
+        copyto!(B, h_twos)
 
         #TODO: check for ocl version, fill is opencl v1.2
         #cl.enqueue_fill(A, 2f0)
         #cl.enqueue_fill(B, 2f0)
 
         cl.enqueue_kernel(k, count)
-        cl.finish(cl.queue())
 
-        r = cl.read(C)
-
-        @test all(x -> x == 4.0, r)
+        @test all(x -> x == 4.0, Array(C))
     end
 
     @testset "enqueue_kernel" begin
@@ -99,29 +91,27 @@
             };"
 
         h_buff = Float32[1,]
-        d_buff = cl.Buffer(Float32, length(h_buff), (:rw, :copy), hostbuf=h_buff)
+        d_arr = CLArray(h_buff)
 
         p = cl.Program(source=simple_kernel) |> cl.build!
         k = cl.Kernel(p, "test")
 
         # dimensions must be the same size
-        @test_throws ArgumentError cl.call(k, d_buff; global_size=(1,), local_size=(1,1))
-        @test_throws ArgumentError cl.call(k, d_buff; global_size=(1,1), local_size=(1,))
+        @test_throws ArgumentError cl.call(k, buffer(d_arr); global_size=(1,), local_size=(1,1))
+        @test_throws ArgumentError cl.call(k, buffer(d_arr); global_size=(1,1), local_size=(1,))
 
         # dimensions are bounded
         max_work_dim = cl.device().max_work_item_dims
         bad = tuple([1 for _ in 1:(max_work_dim + 1)])
 
         # calls are asynchronous, but cl.read blocks
-        cl.call(k, d_buff)
-        r = cl.read(d_buff)
-        @test r[1] == 2
+        cl.call(k, buffer(d_arr))
+        @test Array(d_arr) == [2f0]
 
         # enqueue task is an alias for calling
         # a kernel with a global/local size of 1
         evt = cl.enqueue_task(k)
-        r = cl.read(d_buff)
-        @test r[1] == 3
+        @test Array(d_arr) == [3f0]
     end
 
     @testset "packed structures" begin
@@ -138,11 +128,10 @@
         prg = cl.Program(source = test_source)
         cl.build!(prg)
         structkernel = cl.Kernel(prg, "structest")
-        out = cl.Buffer(Float32, 2, :w)
+        out = CLArray{Float32}(undef, 2)
         bstruct = (1, Int32(4))
-        cl.call(structkernel, out, bstruct)
-        r = cl.read(out)
-        @test r  == [1f0, 4f0]
+        cl.call(structkernel, buffer(out), bstruct)
+        @test Array(out) == [1f0, 4f0]
     end
 
     @testset "vector arguments" begin
@@ -159,13 +148,12 @@
         prg = cl.Program(source = test_source)
         cl.build!(prg)
         vec3kernel = cl.Kernel(prg, "vec3_unpack")
-        out = cl.Buffer(Float32, 6, :w)
+        out = CLArray{Float32}(undef, 6)
         # NOTE: the user is responsible for padding the vector to 4 elements
         #       (only on some platforms)
         vec3_a = (1f0, 2f0, 3f0, 0f0)
         vec3_b = (4f0, 5f0, 6f0, 0f0)
-        cl.call(vec3kernel, out, vec3_a, vec3_b)
-        r = cl.read(out)
-        @test r == [1f0, 2f0, 3f0, 4f0, 5f0, 6f0]
+        cl.call(vec3kernel, buffer(out), vec3_a, vec3_b)
+        @test Array(out) == [1f0, 2f0, 3f0, 4f0, 5f0, 6f0]
     end
 end

--- a/test/memory.jl
+++ b/test/memory.jl
@@ -1,7 +1,7 @@
 @testset "Memory" begin
     function create_test_buffer()
         testarray = zeros(Float32, 1000)
-        cl.Buffer(Float32, length(testarray), (:rw, :copy), hostbuf=testarray)
+        cl.Buffer(testarray)
     end
 
     @testset "context" begin

--- a/test/platform.jl
+++ b/test/platform.jl
@@ -4,9 +4,7 @@
 
         @test cl.platform() != nothing
         @test pointer(cl.platform()) != C_NULL
-        v = opencl_version(cl.platform())
-        @test 1 <= v.major <= 3
-        @test 0 <= v.minor <= 2
+        @test cl.platform().opencl_version isa VersionNumber
     end
 
     @testset "Equality" begin


### PR DESCRIPTION
The Buffer API was pretty messy. In preparation of extending CLArray, this reworks the API to be more similar to other GPU backends, with buffers only providing low-level functionality like `unsafe_copyto!`, and high-level versions like `copy!` or `fill!` only being provided for the `CLArray` type (which should become the only type to be used in user code; it can be converted down to a buffer by calling `buffer` on it).