### PR TITLE
Introduce clcall for ccall-like kernel invocation.

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -20,7 +20,10 @@ Breaking changes:
   objects, have been replaced by `getproperty` overloading on the objects themselves
   (e.g., `cl.info(dev, :name)` and `dev[:name]` are now simply `dev.name`).
 - The blocking `cl.launch` has been replaced by a nonblocking `cl.call`, while also removing
-  the `getindex`-overloading shorthand.
+  the `getindex`-overloading shorthand. However, it's recommended to use the newly-added
+  `cl.clcall` function, which takes an additional tuple type argument and performs automatic
+  conversions of arguments to those types. This makes it possible to pass a `CLArray` to an
+  OpenCL C function expecting Buffer-backed pointers, for example.
 - Argument conversion has been removed; the user should make sure Julia arguments passed to
   kernels match the OpenCL argument types (i.e., no empty types, 4-element tuples for
   a 3-element `float3` arguments).

--- a/lib/memory.jl
+++ b/lib/memory.jl
@@ -8,7 +8,11 @@ abstract type AbstractMemory <: CLObject end
 #     ...
 # end
 
+# for passing buffers to OpenCL APIs: use the underlying handle
 Base.unsafe_convert(::Type{cl_mem}, mem::AbstractMemory) = mem.id
+
+# for passing buffers to kernels: keep the buffer, it's handled by `cl.set_arg!`
+Base.unsafe_convert(::Type{<:Ptr}, mem::AbstractMemory) = mem
 
 Base.pointer(mem::AbstractMemory) = mem.id
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -75,7 +75,7 @@ function Base.reshape(A::CLArray{T}, dims::NTuple{N,Int}) where {T,N}
 end
 
 
-## interop with other arrays
+## conversions
 
 function CLArray(hostarray::AbstractArray{T,N}; kwargs...) where {T, N}
     buf = cl.Buffer(hostarray; kwargs...)
@@ -87,6 +87,10 @@ function Base.Array(A::CLArray{T,N}) where {T, N}
     hA = Array{T}(undef, size(A)...)
     copyto!(hA, A)
     return hA
+end
+
+function Base.cconvert(::Type{Ptr{T}}, A::CLArray{T}) where T
+    buffer(A)
 end
 
 

--- a/test/behaviour.jl
+++ b/test/behaviour.jl
@@ -18,7 +18,7 @@
     prg   = cl.Program(source=hello_world_kernel) |> cl.build!
     kern  = cl.Kernel(prg, "hello")
 
-    cl.call(kern, buffer(out_arr); global_size=str_len)
+    cl.clcall(kern, Tuple{Ptr{Cchar}}, out_arr; global_size=str_len)
     h = Array(out_arr)
 
     @test hello_world_str == GC.@preserve h unsafe_string(pointer(h))
@@ -212,7 +212,8 @@ end
     R_arr = CLArray{Float32}(undef, 10; device=:w)
 
     global_size = size(X)
-    cl.call(part3, buffer(X_arr), buffer(Y_arr), buffer(R_arr), buffer(P_arr); global_size, local_size=nothing)
+    cl.clcall(part3, Tuple{Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Params}},
+                     X_arr, Y_arr, R_arr, P_arr; global_size)
 
     r = Array(R_arr)
     @test all(x -> x == 13.5, r)
@@ -250,7 +251,7 @@ end
 
     P = MutableParams(0.5, 10.0)
     P_arr = CLArray{Float32}(undef, 2)
-    cl.call(part3, buffer(P_arr), P)
+    cl.clcall(part3, Tuple{Ptr{Float32}, MutableParams}, P_arr, P)
 
     r = Array(P_arr)
 


### PR DESCRIPTION
By passing the tuple type, OpenCL.jl can do proper argument conversions, and doesn't rely on the type of the arguments happening to be correct (which can be fragile, e.g., when using literals). In addition, this makes it possible to pass `CLArray`s to kernels expecting a pointer, without having to explicitly access the underlying buffer.