### PR TITLE
Add SVM Buffer type.

### DIFF
--- a/lib/CL.jl
+++ b/lib/CL.jl
@@ -19,6 +19,7 @@ include("cmdqueue.jl")
 include("event.jl")
 include("memory.jl")
 include("buffer.jl")
+include("svm.jl")
 include("program.jl")
 include("kernel.jl")
 

--- a/lib/kernel.jl
+++ b/lib/kernel.jl
@@ -63,13 +63,21 @@ function set_arg!(k::Kernel, idx::Integer, arg::Nothing)
     return k
 end
 
-function set_arg!(k::Kernel, idx::Integer, arg::Ptr{Nothing})
+# SVMBuffers
+## when passing using `cl.call`
+function set_arg!(k::Kernel, idx::Integer, arg::SVMBuffer)
+    clSetKernelArgSVMPointer(k, cl_uint(idx-1), arg.ptr)
+    return k
+end
+## when passing with `cl.clcall`, which has pre-converted the buffer
+function set_arg!(k::Kernel, idx::Integer, arg::Ptr)
     if arg != C_NULL
-        throw(AttributeError("set_arg! for void pointer $arg is undefined"))
+        clSetKernelArgSVMPointer(k, cl_uint(idx-1), arg)
     end
-    set_arg!(k, idx, nothing)
+    return k
 end
 
+# regular buffers
 function set_arg!(k::Kernel, idx::Integer, arg::AbstractMemory)
     arg_boxed = Ref(arg.id)
     clSetKernelArg(k, cl_uint(idx-1), sizeof(cl_mem), arg_boxed)

--- a/lib/svm.jl
+++ b/lib/svm.jl
@@ -1,0 +1,112 @@
+mutable struct SVMBuffer{T}
+    ptr::Ptr{T}
+    len::Int
+
+    function SVMBuffer{T}(len::Integer, access::Symbol=:rw;
+                          fine_grained=false, alignment=nothing) where {T}
+        flags = if access == :rw
+            CL_MEM_READ_WRITE
+        elseif access == :r
+            CL_MEM_READ_ONLY
+        elseif access == :w
+            CL_MEM_WRITE_ONLY
+        else
+            throw(ArgumentError("Invalid access type"))
+        end
+
+        if fine_grained
+            flags |= CL_MEM_SVM_FINE_GRAIN_BUFFER
+        end
+
+        ptr = clSVMAlloc(context(), flags, len * sizeof(T), something(alignment, 0))
+        obj = new{T}(ptr, len)
+        finalizer(obj) do x
+            # TODO: asynchronous free using clEnqueueSVMFree?
+            clSVMFree(context(), x)
+        end
+
+        return obj
+    end
+end
+
+Base.unsafe_convert(::Type{Ptr{T}}, x::SVMBuffer) where {T} = convert(Ptr{T}, x.ptr)
+@inline function Base.pointer(x::SVMBuffer{T}, i::Integer=1) where T
+    Base.unsafe_convert(Ptr{T}, x) + (i-1)*sizeof(T)
+end
+
+Base.ndims(b::SVMBuffer) = 1
+Base.eltype(b::SVMBuffer{T}) where {T} = T
+Base.length(b::SVMBuffer{T}) where {T} = b.len
+Base.sizeof(b::SVMBuffer{T}) where {T} = b.len * sizeof(T)
+
+
+## memory operations
+
+# these generally only make sense for coarse-grained SVM buffers;
+# fine-grained buffers can just be used directly.
+
+# copy from and to SVM buffers
+for (srcty, dstty) in [(:Array, :SVMBuffer), (:SVMBuffer, :Array), (:SVMBuffer, :SVMBuffer)]
+    @eval begin
+        function Base.unsafe_copyto!(dst::$dstty{T}, dst_off::Int, src::$srcty{T}, src_off::Int,
+                                     N::Int; blocking::Bool=false,
+                                     wait_for::Vector{Event}=Event[]) where T
+            nbytes = N * sizeof(T)
+            n_evts  = length(wait_for)
+            evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
+            ret_evt = Ref{cl_event}()
+            clEnqueueSVMMemcpy(queue(), blocking, pointer(dst, dst_off),
+                               pointer(src, src_off), nbytes, n_evts, evt_ids, ret_evt)
+            @return_nanny_event(ret_evt[], dst)
+        end
+        Base.unsafe_copyto!(dst::$dstty, src::$srcty, N; kwargs...) =
+            unsafe_copyto!(dst, 1, src, 1, N; kwargs...)
+    end
+end
+
+# map an SVM buffer into the host address space and return a (pinned) array and an event
+function unsafe_map!(b::SVMBuffer{T}, dims::Dims, flags=:rw; offset::Integer=1,
+                     blocking::Bool=false, wait_for::Vector{Event}=Event[]) where {T}
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
+    flags = if flags == :rw
+        CL_MAP_READ | CL_MAP_WRITE
+    elseif flags == :r
+        CL_MAP_READ
+    elseif flags == :w
+        CL_MAP_WRITE
+    else
+        throw(ArgumentError("enqueue_unmap can have flags of :r, :w, or :rw, got :$flags"))
+    end
+    nbytes  = prod(dims) * sizeof(T)
+    ret_evt = Ref{cl_event}()
+    clEnqueueSVMMap(queue(), blocking, flags, pointer(b, offset), nbytes,
+                    n_evts, evt_ids, ret_evt)
+
+    return unsafe_wrap(Array, pointer(b, offset), dims; own=false), Event(ret_evt[])
+end
+
+# unmap a buffer, return an event
+function unsafe_unmap!(b::SVMBuffer{T}, a::Array{T}; wait_for::Vector{Event}=Event[]) where {T}
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
+    ret_evt = Ref{cl_event}()
+    clEnqueueSVMUnmap(queue(), pointer(a), n_evts, evt_ids, ret_evt)
+    return Event(ret_evt[])
+end
+
+# fill a buffer with a pattern, returning an event
+function unsafe_fill!(b::SVMBuffer{T}, pattern::T, offset::Integer, N::Integer;
+                      wait_for::Vector{Event}=Event[]) where {T}
+    n_evts  = length(wait_for)
+    evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
+    ret_evt = Ref{cl_event}()
+    nbytes = N * sizeof(T)
+    nbytes_pattern = sizeof(T)
+    @assert nbytes_pattern > 0
+    clEnqueueSVMMemFill(queue(), pointer(b, offset), [pattern],
+                        nbytes_pattern, nbytes,
+                        n_evts, evt_ids, ret_evt)
+    @return_event ret_evt[]
+end
+unsafe_fill!(b::SVMBuffer, pattern, N::Integer) = unsafe_fill!(b, pattern, 1, N)


### PR DESCRIPTION
SVM, or shared virtual memory, is similar to both CUDA's UVA and unified memory:

- coarse-grained buffer: like UVA, the address space is shared
- fine-grained buffer: like unified memory, the memory space is shared (without having to map)
- fine-grained system: like HMM, works at the whole system (with existing allocations, IIUC)

This is a requirement for being able to accurately pass Julia objects to OpenCL, because there's no other way to derive device pointers from buffers that I know of.

Not entirely happy with how this is a Buffer that's not a subtype of AbstractMemoryObject, but oh well, we can refactor that later.