### PR TITLE
Avoid promition to Int32 in work_items functions

### DIFF
--- a/lib/intrinsics/Project.toml
+++ b/lib/intrinsics/Project.toml
@@ -5,11 +5,13 @@ version = "0.2.0"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
+GPUToolbox = "096a3bc2-3ced-46d0-87f4-dd12716f4bfc"
 LLVM = "929cbde3-209d-540e-8aea-75f648917ca0"
 SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 ExprTools = "0.1"
+GPUToolbox = "0.2.0"
 LLVM = "9.1"
 SpecialFunctions = "1.3, 2"
 julia = "1.10"

--- a/lib/intrinsics/src/SPIRVIntrinsics.jl
+++ b/lib/intrinsics/src/SPIRVIntrinsics.jl
@@ -7,12 +7,7 @@ import ExprTools
 
 import SpecialFunctions
 
-# helper type for writing UInt32/Int32 literals
-# TODO: upstream this
-struct Literal{T} end
-Base.:(*)(x::Number, ::Type{Literal{T}}) where {T} = T(x)
-const i32 = Literal{Int32}
-const u32 = Literal{UInt32}
+using GPUToolbox
 
 include("pointer.jl")
 include("utils.jl")

--- a/lib/intrinsics/src/SPIRVIntrinsics.jl
+++ b/lib/intrinsics/src/SPIRVIntrinsics.jl
@@ -7,6 +7,13 @@ import ExprTools
 
 import SpecialFunctions
 
+# helper type for writing UInt32/Int32 literals
+# TODO: upstream this
+struct Literal{T} end
+Base.:(*)(x::Number, ::Type{Literal{T}}) where {T} = T(x)
+const i32 = Literal{Int32}
+const u32 = Literal{UInt32}
+
 include("pointer.jl")
 include("utils.jl")
 

--- a/lib/intrinsics/src/work_item.jl
+++ b/lib/intrinsics/src/work_item.jl
@@ -12,17 +12,17 @@ export get_work_dim,
 
 @device_function get_work_dim() = @builtin_ccall("get_work_dim", UInt32, ()) % Int
 
-@device_function get_global_size(dimindx::Integer=1) = @builtin_ccall("get_global_size", UInt, (UInt32,), dimindx-1) % Int
-@device_function get_global_id(dimindx::Integer=1) = @builtin_ccall("get_global_id", UInt, (UInt32,), dimindx-1) % Int + 1
+@device_function get_global_size(dimindx::Integer = 1u32) = @builtin_ccall("get_global_size", UInt, (UInt32,), dimindx - 1u32) % Int
+@device_function get_global_id(dimindx::Integer = 1u32) = @builtin_ccall("get_global_id", UInt, (UInt32,), dimindx - 1u32) % Int + 1
 
-@device_function get_local_size(dimindx::Integer=1) = @builtin_ccall("get_local_size", UInt, (UInt32,), dimindx-1) % Int
-@device_function get_enqueued_local_size(dimindx::Integer=1) = @builtin_ccall("get_enqueued_local_size", UInt, (UInt32,), dimindx-1) % Int
-@device_function get_local_id(dimindx::Integer=1) = @builtin_ccall("get_local_id", UInt, (UInt32,), dimindx-1) % Int + 1
+@device_function get_local_size(dimindx::Integer = 1u32) = @builtin_ccall("get_local_size", UInt, (UInt32,), dimindx - 1u32) % Int
+@device_function get_enqueued_local_size(dimindx::Integer = 1u32) = @builtin_ccall("get_enqueued_local_size", UInt, (UInt32,), dimindx - 1) % Int
+@device_function get_local_id(dimindx::Integer = 1u32) = @builtin_ccall("get_local_id", UInt, (UInt32,), dimindx - 1u32) % Int + 1
 
-@device_function get_num_groups(dimindx::Integer=1) = @builtin_ccall("get_num_groups", UInt, (UInt32,), dimindx-1) % Int
-@device_function get_group_id(dimindx::Integer=1) = @builtin_ccall("get_group_id", UInt, (UInt32,), dimindx-1) % Int + 1
+@device_function get_num_groups(dimindx::Integer = 1u32) = @builtin_ccall("get_num_groups", UInt, (UInt32,), dimindx - 1u32) % Int
+@device_function get_group_id(dimindx::Integer = 1u32) = @builtin_ccall("get_group_id", UInt, (UInt32,), dimindx - 1u32) % Int + 1
 
-@device_function get_global_offset(dimindx::Integer=1) = @builtin_ccall("get_global_offset", UInt, (UInt32,), dimindx-1) % Int + 1
+@device_function get_global_offset(dimindx::Integer = 1u32) = @builtin_ccall("get_global_offset", UInt, (UInt32,), dimindx - 1u32) % Int + 1
 
 @device_function get_global_linear_id() = @builtin_ccall("get_global_linear_id", UInt, ()) % Int + 1
 @device_function get_local_linear_id() = @builtin_ccall("get_local_linear_id", UInt, ()) % Int + 1


### PR DESCRIPTION
The `dimindx-1` would cause a promotion to `Int64` and then a `checked_trunc` to `UInt32`.

```
;  @ /home/vchuravy/.julia/packages/SPIRVIntrinsics/ekvif/src/work_item.jl:16 within `#get_global_id`
define internal fastcc void @julia__get_global_id_13605(i32 zeroext %0) unnamed_addr !dbg !214 {
top:
; ┌ @ /home/vchuravy/.julia/packages/SPIRVIntrinsics/ekvif/src/utils.jl:80 within `macro expansion` @ /home/vchuravy/.julia/packages/LLVM/b3kFs/src/interop/pointer.jl:350
; │┌ @ int.jl:1011 within `-`
; ││┌ @ int.jl:551 within `rem`
; │││┌ @ number.jl:7 within `convert`
; ││││┌ @ boot.jl:892 within `Int64`
; │││││┌ @ boot.jl:816 within `toInt64`
        %1 = zext i32 %0 to i64, !dbg !215
; ││└└└└
; ││ @ int.jl:1013 within `-` @ int.jl:86
    %2 = add nsw i64 %1, -1, !dbg !232
; │└
; │ @ /home/vchuravy/.julia/packages/SPIRVIntrinsics/ekvif/src/utils.jl:80 within `macro expansion` @ /home/vchuravy/.julia/packages/LLVM/b3kFs/src/interop/pointer.jl:344
; │┌ @ essentials.jl:687 within `cconvert`
; ││┌ @ number.jl:7 within `convert`
; │││┌ @ boot.jl:896 within `UInt32`
; ││││┌ @ boot.jl:856 within `toUInt32`
; │││││┌ @ boot.jl:772 within `checked_trunc_uint`
        %3 = icmp ugt i64 %2, 4294967295, !dbg !234
        br i1 %3, label %L9, label %L15, !dbg !234

L9:                                               ; preds = %top
        call fastcc void @julia__throw_inexacterror_13622() #4, !dbg !234
        unreachable, !dbg !234

L15:                                              ; preds = %top
; ││││││ @ boot.jl:770 within `checked_trunc_uint`
        %4 = trunc i64 %2 to i32, !dbg !244
; │└└└└└
; │┌ @ /home/vchuravy/.julia/packages/LLVM/b3kFs/src/interop/pointer.jl:182 within `_typed_llvmcall`
; ││┌ @ /home/vchuravy/.julia/packages/LLVM/b3kFs/src/interop/pointer.jl:182 within `macro expansion` @ /home/vchuravy/.julia/packages/LLVM/b3kFs/src/interop/base.jl:39
     %5 = call i64 @_Z13get_global_idj(i32 %4), !dbg !245
; └└└
; ┌ @ int.jl:87 within `+`
   %6 = add i64 %5, 1, !dbg !250
   ret void, !dbg !250
; └
}
```
