### PR TITLE
Typo fix : pivate -> private

### DIFF
--- a/examples/hands_on_opencl/ex07/matmul.jl
+++ b/examples/hands_on_opencl/ex07/matmul.jl
@@ -142,7 +142,7 @@ for i in 1:COUNT
 end
 
 #--------------------------------------------------------------------------------
-# OpenCL matrix multiplication ... C row per work item, A row in pivate memory
+# OpenCL matrix multiplication ... C row per work item, A row in private memory
 #--------------------------------------------------------------------------------
 kernel_source = read(joinpath(src_dir, "C_row_priv.cl"), String)
 prg  = cl.Program(source=kernel_source) |> cl.build!

--- a/examples/hands_on_opencl/ex08/matmul.jl
+++ b/examples/hands_on_opencl/ex08/matmul.jl
@@ -139,7 +139,7 @@ for i in 1:COUNT
 end
 
 #--------------------------------------------------------------------------------
-# OpenCL matrix multiplication ... C row per work item, A row in pivate memory
+# OpenCL matrix multiplication ... C row per work item, A row in private memory
 #--------------------------------------------------------------------------------
 kernel_source = read(joinpath(src_dir, "C_row_priv_block.cl"), String)
 prg  = cl.Program(source=kernel_source) |> cl.build!
@@ -172,7 +172,7 @@ end
 end
 
 #--------------------------------------------------------------------------------
-# OpenCL matrix multiplication ... C row per work item, A row pivate, B col local
+# OpenCL matrix multiplication ... C row per work item, A row private, B col local
 #--------------------------------------------------------------------------------
 kernel_source = read(joinpath(src_dir, "C_block_form.cl"), String)
 prg  = cl.Program(source=kernel_source) |> cl.build!


### PR DESCRIPTION
The typo is actually coming from Hands on OpenCL but we might as well just fix it here