### PR TITLE
cl.LocalMemory -> CLPtr

### DIFF
--- a/examples/hands_on_opencl/ex08/matmul.jl
+++ b/examples/hands_on_opencl/ex08/matmul.jl
@@ -159,7 +159,7 @@ for i in 1:COUNT
         global_size = (Ndim,)
         local_size = (div(ORDER, 16),)
 
-        evt = clcall(mmul, Tuple{Int32, Int32, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, cl.LocalMem{Float32}},
+        evt = clcall(mmul, Tuple{Int32, Int32, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, CLPtr{Float32}},
                      Mdim, Ndim, Pdim, d_a, d_b, d_c, localmem; global_size, local_size)
         wait(evt)
 

--- a/examples/hands_on_opencl/ex09/pi_ocl.jl
+++ b/examples/hands_on_opencl/ex09/pi_ocl.jl
@@ -68,7 +68,7 @@ global_size = (nwork_groups * work_group_size,)
 local_size  = (work_group_size,)
 localmem    = cl.LocalMem(Float32, work_group_size)
 
-clcall(pi_kernel, Tuple{Int32, Float32, cl.LocalMem{Float32}, Ptr{Float32}},
+clcall(pi_kernel, Tuple{Int32, Float32, CLPtr{Float32}, Ptr{Float32}},
        niters, step_size, localmem, d_partial_sums; global_size, local_size)
 
 cl.copy!(h_psum, d_partial_sums)

--- a/examples/hands_on_opencl/exA/pi_vocl.jl
+++ b/examples/hands_on_opencl/exA/pi_vocl.jl
@@ -107,7 +107,7 @@ global_size = (nwork_groups * work_group_size,)
 local_size  = (work_group_size,)
 localmem    = cl.LocalMem(Float32, work_group_size)
 
-clcall(pi_kernel, Tuple{Int32, Float32, cl.LocalMem{Float32}, Ptr{Float32}},
+clcall(pi_kernel, Tuple{Int32, Float32, CLPtr{Float32}, Ptr{Float32}},
        niters, step_size, localmem, d_partial_sums; global_size, local_size)
 
 cl.copy!(h_psum, d_partial_sums)


### PR DESCRIPTION
I used `cl.LocalMem` in https://github.com/JuliaGPU/OpenCL.jl/pull/291 because I followed what was done in this example
If we follow [your suggestion](https://github.com/JuliaGPU/OpenCL.jl/pull/291#discussion_r2007582501) for the jupyter notebook then I guess we could also update it in the example to be consistent.
