### PR TITLE
Ptr -> CLPtr in examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ d_c = similar(d_a)
 p = cl.Program(; source) |> cl.build!
 k = cl.Kernel(p, "vadd")
 
-clcall(k, Tuple{Ptr{Float32}, Ptr{Float32}, Ptr{Float32}},
+clcall(k, Tuple{CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}},
        d_a, d_b, d_c; global_size=size(a))
 
 c = Array(d_c)

--- a/examples/hands_on_opencl/ex04/vadd_chain.jl
+++ b/examples/hands_on_opencl/ex04/vadd_chain.jl
@@ -81,11 +81,11 @@ vadd = cl.Kernel(program, "vadd")
 # here we call the kernel with work size set to the number of elements and no local
 # work size. This enables the opencl runtime to optimize the local size for simple
 # kernels
-clcall(vadd, Tuple{Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Cuint},
+clcall(vadd, Tuple{CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}, Cuint},
        d_a, d_b, d_c, LENGTH; global_size=size(h_a))
-clcall(vadd, Tuple{Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Cuint},
+clcall(vadd, Tuple{CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}, Cuint},
        d_e, d_c, d_d, LENGTH; global_size=size(h_e))
-clcall(vadd, Tuple{Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Cuint},
+clcall(vadd, Tuple{CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}, Cuint},
        d_g, d_d, d_f, LENGTH; global_size=size(h_g))
 
 # copy back the results from the compute device

--- a/examples/hands_on_opencl/ex05/vadd_abc.jl
+++ b/examples/hands_on_opencl/ex05/vadd_abc.jl
@@ -58,7 +58,7 @@ d_r = CLArray{Float32}(undef, LENGTH)
 vadd = cl.Kernel(program, "vadd")
 
 # execute the kernel over the entire range of the input
-clcall(vadd, Tuple{Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}, Cuint},
+clcall(vadd, Tuple{CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}, Cuint},
        d_a, d_b, d_c, d_r, UInt32(LENGTH); global_size=size(h_a))
 
 # read the results back from the compute device

--- a/examples/hands_on_opencl/ex06/matmul.jl
+++ b/examples/hands_on_opencl/ex06/matmul.jl
@@ -122,7 +122,7 @@ for i in 1:COUNT
     # You can enable profiling events on the queue
     # by calling the constructor with the :profile flag
     cl.queue!(:profile) do
-        evt = clcall(mmul, Tuple{Int32, Int32, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}},
+        evt = clcall(mmul, Tuple{Int32, Int32, Int32, CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}},
                      Mdim, Ndim, Pdim, d_a, d_b, d_c; global_size)
         wait(evt)
 

--- a/examples/hands_on_opencl/ex07/matmul.jl
+++ b/examples/hands_on_opencl/ex07/matmul.jl
@@ -103,7 +103,7 @@ mmul = cl.Kernel(prg, "mmul")
 for i in 1:COUNT
     fill!(h_C, 0.0)
     cl.queue!(:profile) do
-        evt = clcall(mmul, Tuple{Int32, Int32, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}},
+        evt = clcall(mmul, Tuple{Int32, Int32, Int32, CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}},
                      Mdim, Ndim, Pdim, d_a, d_b, d_c; global_size=(Ndim, Mdim))
         wait(evt)
 
@@ -130,7 +130,7 @@ for i in 1:COUNT
     local_size = (div(ORDER, 16),)
 
     cl.queue!(:profile) do
-        evt = clcall(mmul, Tuple{Int32, Int32, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}},
+        evt = clcall(mmul, Tuple{Int32, Int32, Int32, CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}},
                      Mdim, Ndim, Pdim, d_a, d_b, d_c; global_size, local_size)
         wait(evt)
 
@@ -158,7 +158,7 @@ for i in 1:COUNT
     fill!(h_C, 0.0)
 
     cl.queue!(:profile) do
-        evt = clcall(mmul, Tuple{Int32, Int32, Int32, Ptr{Float32}, Ptr{Float32}, Ptr{Float32}},
+        evt = clcall(mmul, Tuple{Int32, Int32, Int32, CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}},
                      Mdim, Ndim, Pdim, d_a, d_b, d_c; global_size=Ndim, local_size=ORDER)
         wait(evt)
 

--- a/examples/notebooks/julia_set_fractal.ipynb
+++ b/examples/notebooks/julia_set_fractal.ipynb
@@ -251,7 +251,7 @@
     "    prg = cl.Program(source=julia_source) |> cl.build!\n",
     "    k = cl.Kernel(prg, \"julia\")\n",
     "\n",
-    "    clcall(k, Tuple{Ptr{ComplexF32}, Ptr{Cushort}, Cushort},\n",
+    "    clcall(k, Tuple{CLPtr{ComplexF32}, CLPtr{Cushort}, Cushort},\n",
     "           q, o, maxiter; global_size=length(q))\n",
     "\n",
     "    return Array(o)\n",

--- a/examples/performance.jl
+++ b/examples/performance.jl
@@ -87,7 +87,7 @@ function cl_performance(ndatapts::Integer, nworkers::Integer)
 
             cl.queue!(:profile) do
                 # call the kernel
-                evt = clcall(kern, Tuple{Ptr{Float32}, Ptr{Float32}, Ptr{Float32}},
+                evt = clcall(kern, Tuple{CLPtr{Float32}, CLPtr{Float32}, CLPtr{Float32}},
                              da, db, dc; global_size, local_size)
                 wait(evt)
 


### PR DESCRIPTION
Applies https://github.com/JuliaGPU/OpenCL.jl/pull/293#discussion_r2009993069 to the README and the scripts in the example folder.
I checked and they're still working after the change
```julia-repl
julia> include("examples/hands_on_opencl/ex04/vadd_chain.jl");
3 vector adds to find F=A+B+E+G: 1024 out of 1024 results were correct

julia> include("examples/hands_on_opencl/ex05/vadd_abc.jl");
3 vector adds to find F=A+B+C: 1024 out of 1024 results were correct

julia> include("examples/hands_on_opencl/ex06/matmul.jl");
[ Info: === Julia, matix mult (dot prod), order 512 ===
0.08164787292480469 seconds at 3287.72136228486 MFLOPS
[ Info: === OpenCL, matrix mult, C(i, j) per work item, order 512 ====
0.073236614 seconds at 3665.317678395126 MFLOPS

julia> include("examples/hands_on_opencl/ex07/matmul.jl");
[ Info: === Julia, matix mult (dot prod), order 512 ===
0.0865471363067627 seconds at 3101.6099140304514 MFLOPS
WARNING: redefinition of constant Main.kernel_source. This may fail, cause incorrect answers, or produce other errors.
[ Info: === OpenCL, matrix mult, C(i, j) per work item, order 512 ====
0.057687135 seconds at 4653.298452072546 MFLOPS
WARNING: redefinition of constant Main.kernel_source. This may fail, cause incorrect answers, or produce other errors.
[ Info: === OpenCL, matrix mult, C row per work item, order 512 ====
0.069053072 seconds at 3887.378913424735 MFLOPS
WARNING: redefinition of constant Main.kernel_source. This may fail, cause incorrect answers, or produce other errors.
┌ Warning: Specified work_size 16384 is bigger than 512
└ @ Main ~/.julia/dev/OpenCL/examples/hands_on_opencl/ex07/matmul.jl:152

julia> include("examples/performance.jl");
Size of test data: 32 MB
Julia Execution time: 0.0061 seconds
====================================================
Platform name:    Intel(R) OpenCL Graphics
Platform profile: FULL_PROFILE
Platform vendor:  Intel(R) Corporation
Platform version: 
----------------------------------------------------
Device name: Intel(R) UHD Graphics 770
Device type: gpu
Device mem: 29559 MB
Device max mem alloc: 4096 MB
Device max clock freq: 1500 MHZ
Device max compute units: 32
Device max work group size: 512
Device max work item size: (512, 512, 512)
Execution time of test: 0.0019 seconds
[ Info: Result norm: 0.0
```