### PR TITLE
Remove check-bounds=yes in tests

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -39,7 +39,8 @@ jobs:
             end'
       - uses: julia-actions/julia-runtest@v1
         with:
-          test_args: '--platform=pocl'
+          # See https://github.com/JuliaGPU/OpenCL.jl/pull/297
+          test_args: ${{ matrix.version == '1.11' && '--platform=pocl --check-bounds=auto' || '--platform=pocl' }}
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5
         with:

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,7 +121,7 @@ const test_exeflags = Base.julia_cmd()
 filter!(test_exeflags.exec) do c
     return !(startswith(c, "--depwarn") || startswith(c, "--check-bounds"))
 end
-#push!(test_exeflags.exec, "--check-bounds=yes")
+push!(test_exeflags.exec, "--check-bounds=auto")
 push!(test_exeflags.exec, "--startup-file=no")
 push!(test_exeflags.exec, "--depwarn=yes")
 push!(test_exeflags.exec, "--project=$(Base.active_project())")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,12 +30,13 @@ if do_help
     println("""
         Usage: runtests.jl [--help] [--list] [--jobs=N] [TESTS...]
 
-               --help             Show this text.
-               --list             List all available tests.
-               --verbose          Print more information during testing.
-               --quickfail        Fail the entire run as soon as a single test errored.
-               --jobs=N           Launch `N` processes to perform tests (default: Sys.CPU_THREADS).
-               --platform=NAME    Run tests on the platform named `NAME` (default: all platforms).
+               --help                        Show this text.
+               --list                        List all available tests.
+               --verbose                     Print more information during testing.
+               --quickfail                   Fail the entire run as soon as a single test errored.
+               --jobs=N                      Launch `N` processes to perform tests (default: Sys.CPU_THREADS).
+               --platform=NAME               Run tests on the platform named `NAME` (default: all platforms).
+               --check-bounds={yes*|no|auto} Julia is launched with this argument
 
                Remaining arguments filter the tests that will be executed.""")
     exit(0)
@@ -121,7 +122,8 @@ const test_exeflags = Base.julia_cmd()
 filter!(test_exeflags.exec) do c
     return !(startswith(c, "--depwarn") || startswith(c, "--check-bounds"))
 end
-push!(test_exeflags.exec, "--check-bounds=auto")
+_, check_bounds = extract_flag!(ARGS, "--check-bounds", "yes")
+push!(test_exeflags.exec, "--check-bounds=$check_bounds")
 push!(test_exeflags.exec, "--startup-file=no")
 push!(test_exeflags.exec, "--depwarn=yes")
 push!(test_exeflags.exec, "--project=$(Base.active_project())")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -121,7 +121,7 @@ const test_exeflags = Base.julia_cmd()
 filter!(test_exeflags.exec) do c
     return !(startswith(c, "--depwarn") || startswith(c, "--check-bounds"))
 end
-push!(test_exeflags.exec, "--check-bounds=yes")
+#push!(test_exeflags.exec, "--check-bounds=yes")
 push!(test_exeflags.exec, "--startup-file=no")
 push!(test_exeflags.exec, "--depwarn=yes")
 push!(test_exeflags.exec, "--project=$(Base.active_project())")

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -30,13 +30,13 @@ if do_help
     println("""
         Usage: runtests.jl [--help] [--list] [--jobs=N] [TESTS...]
 
-               --help                        Show this text.
-               --list                        List all available tests.
-               --verbose                     Print more information during testing.
-               --quickfail                   Fail the entire run as soon as a single test errored.
-               --jobs=N                      Launch `N` processes to perform tests (default: Sys.CPU_THREADS).
-               --platform=NAME               Run tests on the platform named `NAME` (default: all platforms).
-               --check-bounds={yes*|no|auto} Julia is launched with this argument
+                       --help                        Show this text.
+                       --list                        List all available tests.
+                       --verbose                     Print more information during testing.
+                       --quickfail                   Fail the entire run as soon as a single test errored.
+                       --jobs=N                      Launch `N` processes to perform tests (default: Sys.CPU_THREADS).
+                       --platform=NAME               Run tests on the platform named `NAME` (default: all platforms).
+                       --check-bounds={yes*|no|auto} Julia is launched with this argument
 
                Remaining arguments filter the tests that will be executed.""")
     exit(0)
@@ -105,6 +105,8 @@ if do_list
 end
 ## --platform selector
 do_platform, platform = extract_flag!(ARGS, "--platform", nothing)
+## --check-bounds
+_, check_bounds = extract_flag!(ARGS, "--check-bounds", "yes")
 ## no options should remain
 optlike_args = filter(startswith("-"), ARGS)
 if !isempty(optlike_args)
@@ -122,7 +124,6 @@ const test_exeflags = Base.julia_cmd()
 filter!(test_exeflags.exec) do c
     return !(startswith(c, "--depwarn") || startswith(c, "--check-bounds"))
 end
-_, check_bounds = extract_flag!(ARGS, "--check-bounds", "yes")
 push!(test_exeflags.exec, "--check-bounds=$check_bounds")
 push!(test_exeflags.exec, "--startup-file=no")
 push!(test_exeflags.exec, "--depwarn=yes")


### PR DESCRIPTION
The tests are currently failing in CI. I can reproduce it locally they occur in
https://github.com/JuliaGPU/KernelAbstractions.jl/blob/main/test/localmem.jl
I noticed that the failures disappear if I remove `--check-bounds=yes`.
You can reproduce the failure as follows
```julia
$ julia --project=test --check-bounds=yes # v1.11.4
julia> using KernelAbstractions

julia> @kernel function localmem(A)
           N = @uniform prod(@groupsize())
           @uniform begin
               N2 = prod(@groupsize())
           end
           I = @index(Global, Linear)
           i = @index(Local, Linear)
           lmem = @localmem Int (N,) # Ok iff groupsize is static
           @inbounds begin
               lmem[i] = i
               @synchronize
               A[I] = lmem[N2 - i + 1]
           end
       end
localmem (generic function with 4 methods)

julia> using OpenCL, pocl_jll

julia> kernel! = localmem(OpenCLBackend(), 16)
KernelAbstractions.Kernel{OpenCLBackend, KernelAbstractions.NDIteration.StaticSize{(16,)}, KernelAbstractions.NDIteration.DynamicSize, typeof(gpu_localmem)}(OpenCLBackend(), gpu_localmem)

julia> A = CLArray{Int}(undef, 64);

julia> kernel!(A, ndrange = size(A))

julia> Could not find a dominating alternative variable.
[1]    5267 IOT instruction (core dumped)  julia --color=yes --project=test --check-bounds=yes
```
The same runs fine without the `--check-bounds=yes` option.
The error comes from https://github.com/pocl/pocl/blob/66aa142309ecd71d0541f3495dc3ae3f9903b03e/lib/llvmopencl/WorkitemHandler.cc#L264