### PR TITLE
Fix typo in intrinsic mangling, and always test using latest subpackage.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -10,12 +10,7 @@ steps:
         using Pkg
 
         println("--- :julia: Instantiating project")
-        try
-          Pkg.instantiate()
-        catch
-          # if we fail to instantiate, assume that we need newer dependencies
-          Pkg.develop(path="lib/intrinsics")
-        end
+        Pkg.develop(path="lib/intrinsics")
 
         println("+++ :julia: Running tests")
         Pkg.test(; coverage=true, test_args=`--platform=cuda`)'

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -118,12 +118,7 @@ jobs:
         run: |
           julia --project -e '
             using Pkg
-
-            try
-              Pkg.instantiate()
-            catch
-              Pkg.develop(path="lib/intrinsics")
-            end'
+            Pkg.develop(path="lib/intrinsics")'
 
       - name: Test OpenCL.jl
         uses: julia-actions/julia-runtest@v1

--- a/lib/intrinsics/src/utils.jl
+++ b/lib/intrinsics/src/utils.jl
@@ -14,9 +14,9 @@ macro builtin_ccall(name, ret, argtypes, args...)
             "i"
         elseif T == UInt32
             "j"
-        elseif T == UInt64
-            "l"
         elseif T == Int64
+            "l"
+        elseif T == UInt64
             "m"
         elseif T == Int16
             "s"


### PR DESCRIPTION
Fixes these failures I had been seeing locally:

```
Error in testset gpuarrays/math/intrinsics:
Test Failed at /home/tim/.julia/packages/GPUArrays/uiVyU/test/testsuite/math.jl:10
  Expression: compare((x->begin
            #= /home/tim/.julia/packages/GPUArrays/uiVyU/test/testsuite/math.jl:10 =#
            clamp!(x, low, high)
        end), AT, rand(range, N, N))

Error in testset gpuarrays/math/intrinsics:
Test Failed at /home/tim/.julia/packages/GPUArrays/uiVyU/test/testsuite/math.jl:10
  Expression: compare((x->begin
            #= /home/tim/.julia/packages/GPUArrays/uiVyU/test/testsuite/math.jl:10 =#
            clamp!(x, low, high)
        end), AT, rand(range, N, N))

Error in testset gpuarrays/math/intrinsics:
Test Failed at /home/tim/.julia/packages/GPUArrays/uiVyU/test/testsuite/math.jl:10
  Expression: compare((x->begin
            #= /home/tim/.julia/packages/GPUArrays/uiVyU/test/testsuite/math.jl:10 =#
            clamp!(x, low, high)
        end), AT, rand(range, N, N))

Error in testset gpuarrays/math/intrinsics:
Test Failed at /home/tim/.julia/packages/GPUArrays/uiVyU/test/testsuite/math.jl:10
  Expression: compare((x->begin
            #= /home/tim/.julia/packages/GPUArrays/uiVyU/test/testsuite/math.jl:10 =#
            clamp!(x, low, high)
        end), AT, rand(range, N, N))
```