### PR TITLE
Update PoCL to v7.

### DIFF
--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -1,3 +1,6 @@
+# reset the runtime cache from global scope, so that any change triggers recompilation
+GPUCompiler.reset_runtime()
+
 signal_exception() = return
 
 malloc(sz) = C_NULL

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -19,4 +19,4 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 pocl_jll = "627d6b7a-bbe6-5189-83e7-98cc0a5aeadd"
 
 [compat]
-pocl_jll = "6.0"
+pocl_jll = "7.0"


### PR DESCRIPTION
Although testing the upstream build here works fine, https://github.com/JuliaGPU/OpenCL.jl/pull/298, there seem to be some issues with the released PoCL 7.0 JLL as observed on CI: https://github.com/JuliaGPU/OpenCL.jl/actions/runs/14996650877

- [x] macOS: Missing LLVM symbol, probably related to the static linking?
  ```
  ERROR: LoadError: InitError: could not load library "/Users/runner/.julia/artifacts/dfe6b4c7a1d8b04d19182254f89ac364cd88f837/lib/libpocl.2.14.0.dylib"
  dlopen(/Users/runner/.julia/artifacts/dfe6b4c7a1d8b04d19182254f89ac364cd88f837/lib/libpocl.2.14.0.dylib, 0x0001): Symbol not found: __ZTVN4llvm24IRBuilderDefaultInserterE
    Referenced from: <4C4C4400-5555-3144-A122-03A366CBD4D3> /Users/runner/.julia/artifacts/dfe6b4c7a1d8b04d19182254f89ac364cd88f837/lib/libpocl.2.14.0.dylib
    Expected in:     <4C4C442E-5555-3144-A120-874B3EACED5C> /Users/runner/.julia/artifacts/d7730f668c24c66737ad11c207b1e6c5e2ddf5ed/lib/libLLVMSPIRVLib.dylib
  ```

- [x] Ubuntu: `CL_BUILD_PROGRAM_FAILURE`, without a meaningful build log: `Device cpu-haswell-AMD EPYC 7763 64-Core Processor failed to build the program`
- [x] macOS: a LLVMSPIRVLib-related segfault
  ```
  kernelabstractions                            (3) |         failed at 2025-05-28T14:32:43.343
  
  [51966] signal 11 (2): Segmentation fault: 11
  in expression starting at /Users/tim/Julia/pkg/OpenCL/test/kernelabstractions.jl:5
  _ZN4llvm6detail9IEEEFloatD1Ev at /Users/tim/Julia/depot/artifacts/fde7f1bdf8654af0bf45f60e3f490c889bbcd638/lib/libpocl.2.14.0.dylib (unknown line)
  _ZN4llvm12DenseMapBaseINS_8DenseMapINS_7APFloatENSt3__110unique_ptrINS_10ConstantFPENS3_14default_deleteIS5_EEEENS_12DenseMapInfoIS2_vEENS_6detail12DenseMapPairIS  2_S8_EEEES2_S8_SA_SD_E5clearEv at /Users/tim/Julia/depot/artifacts/fde7f1bdf8654af0bf45f60e3f490c889bbcd638/lib/libpocl.2.14.0.dylib (unknown line)
  _ZN4llvm15LLVMContextImplD2Ev at /Users/tim/Julia/depot/artifacts/fde7f1bdf8654af0bf45f60e3f490c889bbcd638/lib/libpocl.2.14.0.dylib (unknown line)
  _ZN4llvm11LLVMContextD1Ev at /Users/tim/Julia/depot/artifacts/fde7f1bdf8654af0bf45f60e3f490c889bbcd638/lib/libpocl.2.14.0.dylib (unknown line)
  pocl_regen_spirv_binary at /Users/tim/Julia/depot/artifacts/fde7f1bdf8654af0bf45f60e3f490c889bbcd638/lib/libpocl.2.14.0.dylib (unknown line)
  pocl_driver_build_binary at /Users/tim/Julia/depot/artifacts/fde7f1bdf8654af0bf45f60e3f490c889bbcd638/lib/libpocl.2.14.0.dylib (unknown line)
  compile_and_link_program at /Users/tim/Julia/depot/artifacts/fde7f1bdf8654af0bf45f60e3f490c889bbcd638/lib/libpocl.2.14.0.dylib (unknown line)
  clBuildProgram at /Users/tim/Julia/depot/artifacts/fde7f1bdf8654af0bf45f60e3f490c889bbcd638/lib/libpocl.2.14.0.dylib (unknown line)
  ```