### PR TITLE
Add sources for SPIRVIntrinsics

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -36,3 +36,6 @@ SPIRV_LLVM_Backend_jll = "20"
 SPIRV_Tools_jll = "2025.1"
 StaticArrays = "1"
 julia = "1.10"
+
+[sources]
+SPIRVIntrinsics = {path="lib/intrinsics"}


### PR DESCRIPTION
Inspired by https://github.com/pocl/pocl/pull/1951 this allows people who clone `OpenCL.jl` and start a `--project=.` to automatically pick up SPIRVIntrinsics. Only works for Julia 1.11 +
