### PR TITLE
KA.__synchronize, add GLOBAL_MEM_FENCE semantics

### DIFF
--- a/src/OpenCLKernels.jl
+++ b/src/OpenCLKernels.jl
@@ -165,7 +165,7 @@ end
 ## Synchronization and Printing
 
 @device_override @inline function KA.__synchronize()
-    SPIRVIntrinsics.barrier(SPIRVIntrinsics.CLK_LOCAL_MEM_FENCE)
+    SPIRVIntrinsics.barrier(SPIRVIntrinsics.CLK_LOCAL_MEM_FENCE | SPIRVIntrinsics.CLK_GLOBAL_MEM_FENCE)
 end
 
 @device_override @inline function KA.__print(args...)


### PR DESCRIPTION
KernelAbstractions (influenced by CUDA) states

> After a `@synchronize` statement all read and writes to global and local memory
> from each thread in the workgroup are visible in from all other threads in the
> workgroup.
