### PR TITLE
[WIP] faster sum

### DIFF
--- a/fast_sum.jl
+++ b/fast_sum.jl
@@ -1,0 +1,46 @@
+using OpenCL, pocl_jll, BenchmarkTools
+
+using SPIRVIntrinsics, Atomix
+
+function sum_columns_subgroup(X, result, M, N)
+    col = get_global_id(1)
+    row_thread = get_global_id(2)
+    row_stride = get_global_size(2)
+
+    if col > N
+        return
+    end
+
+    partial = 0.0f0
+    for row = row_thread:row_stride:M
+        idx = (col - 1) * M + row  # column-major layout
+        partial += X[idx]
+    end
+
+    # Subgroup shuffle-based warp reduction
+    lane = get_sub_group_local_id()
+    width = get_sub_group_size()
+
+    offset = 1
+    while offset < width
+        if lane >= offset
+            other = sub_group_shuffle(partial, lane - offset)
+            partial += other
+        end
+        offset <<= 1
+    end
+
+    # Only one thread writes result
+    if lane == 1
+       Atomix.@atomic result[col] += partial
+    end
+    nothing
+end
+
+
+X = OpenCL.rand(Float32, 1000, 1000)
+out = OpenCL.zeros(Float32, 1000)
+@benchmark begin
+    @opencl local_size = (1, 64) global_size = (1000, 64) extensions = ["SPV_EXT_shader_atomic_float_add"] sum_columns_subgroup(X, out, 1000, 1000)
+    OpenCL.synchronize(out)
+end

--- a/lib/intrinsics/src/atomic.jl
+++ b/lib/intrinsics/src/atomic.jl
@@ -57,6 +57,15 @@ for gentype in atomic_integer_types, as in atomic_memory_types
 end
 end
 
+for gentype in [Float32, Float64], as in atomic_memory_types
+@eval begin
+
+@device_function atomic_add!(p::LLVMPtr{$gentype,$as}, val::$gentype) =
+    @builtin_ccall("atomic_add", $gentype,
+                   (LLVMPtr{$gentype,$as}, $gentype), p, val)
+end
+end
+
 
 # specifically typed
 

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -4,7 +4,7 @@ export @opencl, clfunction
 ## high-level @opencl interface
 
 const MACRO_KWARGS = [:launch]
-const COMPILER_KWARGS = [:kernel, :name, :always_inline]
+const COMPILER_KWARGS = [:kernel, :name, :always_inline, :extensions]
 const LAUNCH_KWARGS = [:global_size, :local_size, :queue]
 
 macro opencl(ex...)


### PR DESCRIPTION
ref #352

This matches the speed of the C implementation, so there seems to be no inherent overhead compared to OpenCL C:

```
BenchmarkTools.Trial: 10000 samples with 1 evaluation per sample.
 Range (min … max):  221.027 μs …  2.753 ms  ┊ GC (min … max): 0.00% … 0.00%
 Time  (median):     295.657 μs              ┊ GC (median):    0.00%
 Time  (mean ± σ):   309.097 μs ± 74.218 μs  ┊ GC (mean ± σ):  0.00% ± 0.00%

          ▁▄▅▇▇█▇▆▄▄▂▁▁                                         
  ▂▂▁▂▃▃▄▆██████████████▆▆▆▆▆▅▄▄▄▄▃▃▃▃▃▃▂▃▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂▂ ▄
  221 μs          Histogram: frequency by time          510 μs <

 Memory estimate: 2.42 KiB, allocs estimate: 56.
```

cc @maleadt
