### PR TITLE
TagBot: use DOCUMENTER_KEY

### DIFF
--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -28,3 +28,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
+          ssh: ${{ secrets.DOCUMENTER_KEY }}


### PR DESCRIPTION
This is needed for TagBot to be able to trigger documentation builds upon pushing new tags. See https://documenter.juliadocs.org/dev/man/hosting/#TagBot-and-tagged-versions-2a42332b0ef7aead