### PR TITLE
CI: Build PoCL without hwloc.

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -99,16 +99,15 @@ jobs:
             julia --project=pocl --color=yes -e '
               using LLVM_full_jll,
                     SPIRV_Tools_jll, SPIRV_LLVM_Translator_jll,
-                    OpenCL_jll, OpenCL_Headers_jll,
-                    Hwloc_jll, CMake_jll
+                    OpenCL_jll, OpenCL_Headers_jll, CMake_jll
 
               sourcedir = joinpath(@__DIR__, "pocl")
               builddir = joinpath(@__DIR__, "build")
               destdir = joinpath(@__DIR__, "target")
 
               prefix = []
-              for jll in [SPIRV_Tools_jll, SPIRV_LLVM_Translator_jll, OpenCL_jll,
-                          OpenCL_Headers_jll, Hwloc_jll]
+              for jll in [SPIRV_Tools_jll, SPIRV_LLVM_Translator_jll,
+                          OpenCL_jll, OpenCL_Headers_jll]
                   push!(prefix, jll.artifact_dir)
               end
 


### PR DESCRIPTION
It seems optional, and for some reason results in compilation errors only on CI.

Addresses part of https://github.com/JuliaGPU/OpenCL.jl/issues/366