### PR TITLE
allow disabling validation

### DIFF
--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -4,7 +4,7 @@ export @opencl, clfunction
 ## high-level @opencl interface
 
 const MACRO_KWARGS = [:launch]
-const COMPILER_KWARGS = [:kernel, :name, :always_inline, :extensions, :backend]
+const COMPILER_KWARGS = [:kernel, :name, :always_inline, :extensions, :backend, :validate]
 const LAUNCH_KWARGS = [:global_size, :local_size, :queue]
 
 macro opencl(ex...)


### PR DESCRIPTION
While writing tests for eschnett/SIMD.jl#147, I noticed that `spirv-val` doesn't seem to understand the `SPV_INTEL_masked_gather_scatter` extension and fails if it encounters vectors containing pointers. Ideally should be fixed upstream, but add an option to disable validation for now.