### PR TITLE
Use `macos-15-intel`

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1.10', '1.11']
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-13, macOS-15, windows-2025]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-15, macOS-15-intel, windows-2025]
         arch: [x64, arm64]
         pocl: [jll, local]
         memory_backend: [usm, svm, buffer]
@@ -38,10 +38,10 @@ jobs:
           # macOS 13 is Intel-only, while macOS 14+ only support Apple Silicon
           - os: macOS-15
             arch: x64
-          - os: macOS-13
+          - os: macOS-15-intel
             arch: arm64
           # we only test building PoCL on Linux
-          - os: macOS-13
+          - os: macOS-15-intel
             pocl: local
           - os: macOS-15
             pocl: local


### PR DESCRIPTION
macos 13 images are going away soon so replace the Intel runners with `macos-15-intel` runners.