### PR TITLE
GPUToolbox compat again

### DIFF
--- a/lib/intrinsics/Project.toml
+++ b/lib/intrinsics/Project.toml
@@ -1,7 +1,7 @@
 name = "SPIRVIntrinsics"
 uuid = "71d1d633-e7e8-4a92-83a1-de8814b09ba8"
 authors = ["Tim Besard <tim.besard@gmail.com>"]
-version = "0.5.1"
+version = "0.5.2"
 
 [deps]
 ExprTools = "e2ba6199-217a-4e67-a87a-7c52f15ade04"
@@ -11,7 +11,7 @@ SpecialFunctions = "276daf66-3868-5448-9aa4-cd146d93841b"
 
 [compat]
 ExprTools = "0.1"
-GPUToolbox = "0.2, 0.3"
+GPUToolbox = "0.2, 0.3, 1"
 LLVM = "9.1"
 SpecialFunctions = "1.3, 2"
 julia = "1.10"


### PR DESCRIPTION
SPIRVIntrinsics compat for GPUToolbox v1 will be particularly important for preventing resolver issues once KernelAbstractions 0.10 is released since it'll make SPIRVIntrinsics an indirect dependency for all the other backends.

I know it's annoying to tag a new release so soon after a release for the same reason but GPUToolBox v1 release will make these breakages non-existent