### PR TITLE
Use `--quickfail` in CI

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -141,7 +141,7 @@ jobs:
         uses: julia-actions/julia-runtest@v1
         if: runner.os != 'Windows'
         with:
-          test_args: '--platform=pocl'
+          test_args: '--quickfail --platform=pocl'
 
       - name: Setup BusyBox
         if: runner.os == 'Windows'
@@ -153,7 +153,7 @@ jobs:
         run: |
           using Pkg
           Pkg.activate(".")
-          Pkg.test(; test_args=`--platform=pocl`)
+          Pkg.test(; test_args=`--quickfail --platform=pocl`)
 
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v5


### PR DESCRIPTION
This should reduce the CI burden for non-hanging tests.