### PR TITLE
re-enable FP16 tests on PoCL

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -60,7 +60,8 @@ jobs:
         if: ${{ matrix.pocl == 'local' }}
         uses: actions/checkout@v6
         with:
-          repository: pocl/pocl
+          repository: franz/pocl
+          ref: fixes
           path: pocl
 
       - name: Install system dependencies

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -60,8 +60,7 @@ jobs:
         if: ${{ matrix.pocl == 'local' }}
         uses: actions/checkout@v6
         with:
-          repository: franz/pocl
-          ref: fixes
+          repository: pocl/pocl
           path: pocl
 
       - name: Install system dependencies

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ matrix.pocl == 'local' }}
         run: |
           sudo apt-get update
-          sudo apt-get install -y build-essential cmake ninja-build pkg-config
+          sudo apt-get install -y build-essential cmake ninja-build pkg-config libsleef-dev
 
       - name: Install Julia dependencies
         if: ${{ matrix.pocl == 'local' }}

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -96,8 +96,7 @@ end
         if f == acosh
             x += 1
         end
-        broken = ispocl && T == Float16 && f in [acosh, asinh, atanh, cbrt, cospi, expm1, log1p, sinpi, tanpi]
-        @test call_on_device(f, x) ≈ f(x) broken = broken
+        @test call_on_device(f, x) ≈ f(x)
     end
 end
 
@@ -112,8 +111,7 @@ end
         ]
         x = rand(T)
         y = rand(T)
-        broken = ispocl && T == Float16 && f == atan
-        @test call_on_device(f, x, y) ≈ f(x, y) broken = broken
+        @test call_on_device(f, x, y) ≈ f(x, y)
     end
 end
 
@@ -138,7 +136,7 @@ end
             OpenCL.rsqrt,
         ]
         x = rand(T)
-        broken = ispocl && T == Float16 && !(f in [OpenCL.rint, OpenCL.rsqrt])
+        broken = ispocl && T == Float16 && (f == OpenCL.logb)
         @test call_on_device(f, x) isa Real broken = broken  # Just check it doesn't error
     end
     broken = ispocl && T == Float16
@@ -157,7 +155,7 @@ end
         ]
         x = rand(T)
         y = rand(T)
-        broken = ispocl && T == Float16 && !(f in [OpenCL.maxmag, OpenCL.minmag])
+        broken = ispocl && T == Float16 && (f in [OpenCL.nextafter, OpenCL.powr])
         @test call_on_device(f, x, y) isa Real broken = broken  # Just check it doesn't error
     end
     broken = ispocl && T == Float16


### PR DESCRIPTION
These tests should work on the CI after https://github.com/pocl/pocl/pull/2128 lands in PoCL's main branch. Currently the PR is failing with errors like:

```
Error During Test at /home/runner/work/pocl/pocl/OpenCL.jl/test/intrinsics.jl:116
 Unexpected Pass
 Expression: call_on_device(f, x, y) ≈ f(x, y)
 Got correct result, please change to @test if no longer broken.
```

(the FP16 support in PoCL is still not 100% complete, but with the PR it'll be quite close)