### PR TITLE
Fix CI failures: require fixed PoCL and drop Intel macOS

### DIFF
--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -23,7 +23,7 @@ jobs:
       fail-fast: false
       matrix:
         version: ['1.10', '1.12']
-        os: [ubuntu-24.04, ubuntu-24.04-arm, macOS-26-intel, windows-2022]
+        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022]
         arch: [x64, arm64]
         pocl: [jll, local]
         memory_backend: [usm, svm, buffer]
@@ -35,12 +35,7 @@ jobs:
             arch: arm64
           - os: ubuntu-24.04-arm
             arch: x64
-          # macOS-26-intel is Intel-only
-          - os: macOS-26-intel
-            arch: arm64
           # we only test building PoCL on Linux
-          - os: macOS-26-intel
-            pocl: local
           - os: windows-2022
             pocl: local
     steps:
@@ -128,17 +123,12 @@ jobs:
       - name: "Set test arguments and other environment variables"
         shell: bash
         run: |
-          if [[ ${{ runner.os }} == "macOS" ]]; then
-            JULIA_TEST_MAXRSS_MB=1800
-            echo "JULIA_TEST_MAXRSS_MB=${JULIA_TEST_MAXRSS_MB}" | tee -a "${GITHUB_ENV}"
-            JULIA_CPU_THREADS=2
-            echo "JULIA_CPU_THREADS=${JULIA_CPU_THREADS}" | tee -a "${GITHUB_ENV}"
-          fi
-
           # PoCL's default work-group lowering (loopvec) miscompiles
-          # barrier-heavy kernels on some CPUs, resulting in infinite loops
-          # or incorrect results (JuliaGPU/OpenCL.jl#388, pocl/pocl#1971);
-          # on Intel macOS with Julia 1.10 this reliably deadlocked CI.
+          # barrier-heavy kernels on some CPUs (e.g. Zen 4/5, some Intel),
+          # resulting in infinite loops or incorrect results
+          # (JuliaGPU/OpenCL.jl#388, pocl/pocl#1971); this reliably
+          # deadlocked CI on the (now removed) Intel macOS runners, and
+          # GitHub-hosted runners occasionally come with affected CPUs.
           # Use the continuation-based synchronization method instead.
           echo "POCL_WORK_GROUP_METHOD=cbs" | tee -a "${GITHUB_ENV}"
 

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -135,6 +135,13 @@ jobs:
             echo "JULIA_CPU_THREADS=${JULIA_CPU_THREADS}" | tee -a "${GITHUB_ENV}"
           fi
 
+          # PoCL's default work-group lowering (loopvec) miscompiles
+          # barrier-heavy kernels on some CPUs, resulting in infinite loops
+          # or incorrect results (JuliaGPU/OpenCL.jl#388, pocl/pocl#1971);
+          # on Intel macOS with Julia 1.10 this reliably deadlocked CI.
+          # Use the continuation-based synchronization method instead.
+          echo "POCL_WORK_GROUP_METHOD=cbs" | tee -a "${GITHUB_ENV}"
+
       - name: Setup OpenCL.jl
         run: |
           echo '[OpenCL]' >> test/LocalPreferences.toml

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -120,18 +120,6 @@ jobs:
             echo '[pocl_jll]' >> test/LocalPreferences.toml
             echo 'libpocl_path="${{ github.workspace }}/target/lib/libpocl.so"' >> test/LocalPreferences.toml
 
-      - name: "Set test arguments and other environment variables"
-        shell: bash
-        run: |
-          # PoCL's default work-group lowering (loopvec) miscompiles
-          # barrier-heavy kernels on some CPUs (e.g. Zen 4/5, some Intel),
-          # resulting in infinite loops or incorrect results
-          # (JuliaGPU/OpenCL.jl#388, pocl/pocl#1971); this reliably
-          # deadlocked CI on the (now removed) Intel macOS runners, and
-          # GitHub-hosted runners occasionally come with affected CPUs.
-          # Use the continuation-based synchronization method instead.
-          echo "POCL_WORK_GROUP_METHOD=cbs" | tee -a "${GITHUB_ENV}"
-
       - name: Setup OpenCL.jl
         run: |
           echo '[OpenCL]' >> test/LocalPreferences.toml

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -26,5 +26,6 @@ Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 pocl_jll = "627d6b7a-bbe6-5189-83e7-98cc0a5aeadd"
 
 [compat]
-pocl_jll = "7.0"
+# pocl 7.1.2 includes a fix for crashes when freeing USM memory (#317)
+pocl_jll = "7.1.2"
 ParallelTestRunner = "2.2"


### PR DESCRIPTION
CI has been red on main for a while. Investigation of the recent runs shows two independent issues:

## Windows: access violation in `pocl_reset_indirect_ptrs` (#317)

USM jobs on Windows crashed in `pocl_reset_indirect_ptrs` (e.g. [this job](https://github.com/JuliaGPU/OpenCL.jl/actions/runs/26944522358/job/79494039212)). This was fixed upstream (pocl/pocl#2188, backported in JuliaPackaging/Yggdrasil#13896) and shipped in pocl_jll 7.1.2; runs since June 4 no longer exhibit the crash. This PR requires `pocl_jll = "7.1.2"` in the test environment so the resolver can't pick known-bad builds again.

## Intel macOS + Julia 1.10: jobs hang until timeout

All `macOS-26-intel` + Julia 1.10 jobs (9/9 over the last three runs on main/PRs) hung until the 100-minute timeout. Log analysis shows the runner kept making progress: in every job, one worker started a testset that never finished while the others completed the rest of the suite. The hung testset was different every time (`gpuarrays/linalg/norm`, `intrinsics`, `device/random`, `gpuarrays/statistics`, `kernelabstractions`, ...), so this is not a bug in a specific test.

This is not fixed by JuliaGPU/GPUCompiler.jl#812: the hanging jobs already ran GPUCompiler v1.20.0, which includes that change (it shipped in v1.13.3), and the local reproducer below still hangs with v1.21.0.

The hang is reproducible locally on Linux (AMD Zen 5) with Julia 1.10 using the MWE from #388:

```julia
using OpenCL, AcceleratedKernels, pocl_jll
x = CLArray([1, 2, 3, 4, 5])
y = AcceleratedKernels.cumsum(x)  # spins forever at 100% CPU inside the kernel
```

The host side just blocks waiting on the device-to-host copy while a PoCL worker thread spins inside the kernel, i.e. PoCL's default work-group lowering (`loopvec`) miscompiles barrier-heavy kernels into infinite loops on some CPUs (and produces silently incorrect results at other block sizes; see #388 and pocl/pocl#1971 — also reminiscent of the Julia 1.10-specific crashes PoCL's upstream CI sees on Zen 4, #417).

This PR therefore:
- drops Intel macOS from the test matrix altogether (GitHub is phasing those runners out anyway);
- sets `POCL_WORK_GROUP_METHOD=cbs` for the remaining test jobs: the miscompilation isn't macOS-specific (reproduced on Linux/Zen 5), and GitHub-hosted runners occasionally come with affected CPUs (PoCL's upstream CI hits this on GitHub-hosted Zen 4 runners, #417).

🤖 Generated with [Claude Code](https://claude.com/claude-code)