### PR TITLE
Add compile-time device feature queries

### DIFF
--- a/lib/cl/kernel.jl
+++ b/lib/cl/kernel.jl
@@ -202,15 +202,22 @@ function enqueue_kernel(k::Kernel, global_work_size, local_work_size=nothing;
     end
 
     if rng_state
-        if local_work_size !== nothing
-            num_sub_groups = KernelSubGroupInfo(k, device(), lsize).sub_group_count
+        # match the device-side RNG layout (src/device/random.jl): one slot per subgroup when the
+        # device supports subgroups, else one slot per work-item.
+        use_subgroups = sub_groups_supported(device())
+        num_slots = if use_subgroups
+            if local_work_size !== nothing
+                KernelSubGroupInfo(k, device(), lsize).sub_group_count
+            else
+                KernelSubGroupInfo(k, device(), Csize_t[]).max_num_sub_groups
+            end
         else
-            num_sub_groups = KernelSubGroupInfo(k, device(), Csize_t[]).max_num_sub_groups
+            local_work_size !== nothing ? prod(lsize) : device().max_work_group_size
         end
         if nargs === nothing
             nargs = k.num_args - 2
         end
-        rng_state_size = sizeof(UInt32) * num_sub_groups
+        rng_state_size = sizeof(UInt32) * num_slots
         set_arg!(k, nargs + 1, LocalMem(UInt32, rng_state_size))
         set_arg!(k, nargs + 2, LocalMem(UInt32, rng_state_size))
     end

--- a/src/OpenCL.jl
+++ b/src/OpenCL.jl
@@ -33,6 +33,7 @@ include("memory.jl")
 include("array.jl")
 
 # compiler implementation
+include("compiler/capabilities.jl")
 include("compiler/compilation.jl")
 include("compiler/execution.jl")
 include("compiler/reflection.jl")

--- a/src/compiler/capabilities.jl
+++ b/src/compiler/capabilities.jl
@@ -1,0 +1,110 @@
+## Optional device features ("aspects")
+#
+# A flat set of optional capabilities, like SYCL 2020 aspects. A single OpenCL C version number
+# isn't enough: NVIDIA and pocl both report OpenCL C 1.2 but differ on subgroups. Each `FEATURES`
+# entry is a `name` and a host-side `detect` query; a device profile is a `FeatureSet` bitset
+# indexed by position, so adding a feature just claims the next bit (no GPUCompiler release needed).
+#
+# We don't validate a kernel's feature use against the device; the driver rejects incompatible
+# SPIR-V/OpenCL C itself. Kernels select features at compile time with `has_feature` and supply
+# their own fallback (see the device RNG).
+
+struct Feature
+    name::Symbol
+    detect::Function
+end
+
+# OpenCL 3.0: array of cl_name_version {cl_version (4 bytes); char name[64]}. Returns [] on
+# devices that don't support the query (e.g. OpenCL 1.2).
+function opencl_c_features(dev::cl.Device)::Vector{String}
+    CL_DEVICE_OPENCL_C_FEATURES = 0x106f
+    try
+        sz = Ref{Csize_t}(0)
+        cl.clGetDeviceInfo(dev, CL_DEVICE_OPENCL_C_FEATURES, 0, C_NULL, sz)
+        sz[] == 0 && return String[]
+        buf = Vector{UInt8}(undef, sz[])
+        cl.clGetDeviceInfo(dev, CL_DEVICE_OPENCL_C_FEATURES, sz[], buf, C_NULL)
+        entry = 68  # sizeof(cl_name_version)
+        feats = String[]
+        for off in 0:entry:(length(buf) - entry)
+            namebytes = @view buf[(off + 5):(off + entry)]   # skip the 4-byte version
+            nul = findfirst(==(0x00), namebytes)
+            name = String(namebytes[1:(nul === nothing ? length(namebytes) : nul - 1)])
+            isempty(name) || push!(feats, name)
+        end
+        return feats
+    catch
+        return String[]
+    end
+end
+
+has_opencl_c_feature(dev, feat) = feat in opencl_c_features(dev)
+
+const FEATURES = Feature[
+    Feature(:fp16, dev -> "cl_khr_fp16" in dev.extensions),
+    Feature(:fp64, dev -> "cl_khr_fp64" in dev.extensions),
+    Feature(:int64_atomics, dev -> "cl_khr_int64_base_atomics" in dev.extensions),
+    Feature(:subgroups, cl.sub_groups_supported),
+    Feature(:generic_address_space,
+            dev -> has_opencl_c_feature(dev, "__opencl_c_generic_address_space")),
+]
+
+const FeatureSet = UInt64
+@assert length(FEATURES) <= 64
+
+function feature_index(name::Symbol)
+    for (i, f) in enumerate(FEATURES)
+        f.name === name && return i
+    end
+    throw(ArgumentError("unknown OpenCL feature $name"))
+end
+
+feature_bit(name::Symbol) = one(FeatureSet) << (feature_index(name) - 1)
+feature_supported(fs::FeatureSet, name::Symbol) = (fs & feature_bit(name)) != 0
+
+"""
+    device_features(dev::cl.Device) -> FeatureSet
+
+The set of optional features the device supports.
+"""
+function device_features(dev::cl.Device)::FeatureSet
+    fs = zero(FeatureSet)
+    for (i, f) in enumerate(FEATURES)
+        f.detect(dev) && (fs |= one(FeatureSet) << (i - 1))
+    end
+    return fs
+end
+
+feature_supported(dev::cl.Device, name::Symbol) = feature_supported(device_features(dev), name)
+
+
+## compile-time feature queries (device side, folded to a constant by the optimizer)
+
+# Load the feature bitset that `finish_module!` materializes as a module-scope constant. Once the
+# constant is in place the load folds away, so `has_feature` branches resolve at compile time. The
+# global uses the UniformConstant (2) storage class to stay valid SPIR-V if it ever survives.
+@device_function @inline function feature_bitset()
+    Base.llvmcall(
+        ("""@__opencl_feature_bitset = external addrspace(2) global i64
+            define i64 @entry() #0 {
+                %v = load i64, i64 addrspace(2)* @__opencl_feature_bitset
+                ret i64 %v
+            }
+            attributes #0 = { alwaysinline }
+        """, "entry"), UInt64, Tuple{})
+end
+
+export has_feature
+
+"""
+    has_feature(name::Symbol) -> Bool
+
+Compile-time query (device side): does the kernel's target device support optional feature `name`
+(see `FEATURES`)? Folds to a constant, so `if has_feature(:subgroups) … else … end` keeps only the
+live branch. Host-side, use `feature_supported(dev, name)`.
+"""
+@inline has_feature(name::Symbol) = has_feature(Val(name))
+@generated function has_feature(::Val{name}) where {name}
+    bit = feature_bit(name)   # resolved at compile time from the registry
+    return :((feature_bitset() & $bit) != zero(FeatureSet))
+end

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -3,6 +3,8 @@
 Base.@kwdef struct OpenCLCompilerParams <: AbstractCompilerParams
     # request a fixed sub-group width via `intel_reqd_sub_group_size`
     sub_group_size::Union{Nothing,Int} = nothing
+    # optional features the target device supports, exposed to kernels via `has_feature`
+    features::FeatureSet = zero(FeatureSet)
 end
 
 const OpenCLCompilerConfig = CompilerConfig{SPIRVCompilerTarget, OpenCLCompilerParams}
@@ -36,6 +38,16 @@ function GPUCompiler.finish_module!(@nospecialize(job::OpenCLCompilerJob),
     sg_size = job.config.params.sub_group_size
     if sg_size !== nothing
         metadata(entry)["intel_reqd_sub_group_size"] = MDNode([ConstantInt(Int32(sg_size))])
+    end
+
+    # materialize the feature bitset for `has_feature`, if the kernel referenced it. A constant
+    # initializer plus private linkage lets the optimizer fold the loads and drop the global, so it
+    # never reaches SPIR-V.
+    if haskey(globals(mod), "__opencl_feature_bitset")
+        gv = globals(mod)["__opencl_feature_bitset"]
+        initializer!(gv, ConstantInt(LLVM.Int64Type(), job.config.params.features))
+        linkage!(gv, LLVM.API.LLVMPrivateLinkage)
+        constant!(gv, true)
     end
 
     # if this kernel uses our RNG, we should prime the shared state.
@@ -148,7 +160,7 @@ end
 
     # create GPUCompiler objects
     target = SPIRVCompilerTarget(; supports_fp16, supports_fp64, validate=true, kwargs...)
-    params = OpenCLCompilerParams(; sub_group_size)
+    params = OpenCLCompilerParams(; sub_group_size, features=device_features(dev))
     CompilerConfig(target, params; kernel, name, always_inline)
 end
 

--- a/src/device/random.jl
+++ b/src/device/random.jl
@@ -3,25 +3,45 @@
 using Random
 import RandomNumbers
 
-# local memory with the actual seed, per subgroup, set by `initialize_rng_state`` or overridden by calling `seed!`
-@inline function global_random_keys()
-    n = get_num_sub_groups()
-    ptr = random_keys()::LLVMPtr{UInt32, AS.Workgroup}
-    return CLDeviceArray{UInt32, 1, AS.Workgroup}((n,), ptr)
+# RNG state lives in work-group-local memory. With subgroups, one (key, counter) slot per subgroup
+# indexed by subgroup id; without, one slot per work-item indexed by its linear id in the work-group.
+# `has_feature(:subgroups)` folds at compile time, so only one layout is emitted; the host sizes the
+# local memory to match (see `enqueue_kernel`).
+@inline rng_nslots() =
+    has_feature(:subgroups) ? Int(get_num_sub_groups()) :
+                              Int(get_local_size(1) * get_local_size(2) * get_local_size(3))
+@inline function rng_slot()   # 1-based slot index for this work-item
+    if has_feature(:subgroups)
+        return Int(get_sub_group_id())
+    else
+        lx = get_local_id(1) - 1; ly = get_local_id(2) - 1; lz = get_local_id(3) - 1
+        return lx + get_local_size(1) * (ly + get_local_size(2) * lz) + 1
+    end
+end
+# global linear id from get_global_id/get_global_size (always available), avoiding the OpenCL 2.0
+# get_global_linear_id builtin.
+@inline function global_linear_id()
+    gx = get_global_id(1) - 1; gy = get_global_id(2) - 1; gz = get_global_id(3) - 1
+    return gx + get_global_size(1) * (gy + get_global_size(2) * gz) + 1
 end
 
-# local memory with per-subgroup counters, incremented when generating numbers
+# local memory with the actual seed, set by `initialize_rng_state` or overridden by `seed!`
+@inline function global_random_keys()
+    ptr = random_keys()::LLVMPtr{UInt32, AS.Workgroup}
+    return CLDeviceArray{UInt32, 1, AS.Workgroup}((rng_nslots(),), ptr)
+end
+
+# local memory with per-slot counters, incremented when generating numbers
 @inline function global_random_counters()
-    n = get_num_sub_groups()
     ptr = random_counters()::LLVMPtr{UInt32, AS.Workgroup}
-    return CLDeviceArray{UInt32, 1, AS.Workgroup}((n,), ptr)
+    return CLDeviceArray{UInt32, 1, AS.Workgroup}((rng_nslots(),), ptr)
 end
 
 # initialization function, called automatically at the start of each kernel
 function initialize_rng_state()
-    subgroup_id = get_sub_group_id()
-    @inbounds global_random_keys()[subgroup_id] = kernel_state().random_seed
-    @inbounds global_random_counters()[subgroup_id] = 0
+    slot = rng_slot()
+    @inbounds global_random_keys()[slot] = kernel_state().random_seed
+    @inbounds global_random_counters()[slot] = 0
 end
 
 # generators
@@ -35,24 +55,20 @@ struct Philox2x32{R} <: RandomNumbers.AbstractRNG{UInt64} end
 @inline Philox2x32() = Philox2x32{7}()
 
 @inline function Base.getproperty(rng::Philox2x32, field::Symbol)
-    subgroup_id = get_sub_group_id()
-
     if field === :key
-        @inbounds global_random_keys()[subgroup_id]
+        @inbounds global_random_keys()[rng_slot()]
     elseif field === :ctr1
-        @inbounds global_random_counters()[subgroup_id]
+        @inbounds global_random_counters()[rng_slot()]
     elseif field === :ctr2
-        unsafe_trunc(UInt32, get_global_linear_id())
+        unsafe_trunc(UInt32, global_linear_id())
     end
 end
 
 @inline function Base.setproperty!(rng::Philox2x32, field::Symbol, x)
-    subgroup_id = get_sub_group_id()
-
     if field === :key
-        @inbounds global_random_keys()[subgroup_id] = x
+        @inbounds global_random_keys()[rng_slot()] = x
     elseif field === :ctr1
-        @inbounds global_random_counters()[subgroup_id] = x
+        @inbounds global_random_counters()[rng_slot()] = x
     end
     return rng
 end

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -149,3 +149,21 @@ end
         @test occursin("target triple = \"spir64-unknown-unknown\"", llvm_backend_khronos)
     end
 end
+
+@testset "has_feature folding" begin
+    # has_feature must fold at compile time: the feature-bitset global gets baked in and DCE'd,
+    # leaving only the branch matching the device.
+    function feature_select(a)
+        @inbounds a[] = has_feature(:subgroups) ? Int32(12345) : Int32(54321)
+        return
+    end
+    ir = sprint(io -> OpenCL.code_llvm(io, feature_select,
+                                       Tuple{CLDeviceArray{Int32, 0, AS.CrossWorkgroup}};
+                                       kernel = true))
+    @test !occursin("__opencl_feature_bitset", ir)
+    if OpenCL.feature_supported(cl.device(), :subgroups)
+        @test occursin("12345", ir) && !occursin("54321", ir)
+    else
+        @test occursin("54321", ir) && !occursin("12345", ir)
+    end
+end

--- a/test/intrinsics.jl
+++ b/test/intrinsics.jl
@@ -35,12 +35,14 @@ const simd_ns = (Sys.iswindows() && ispocl) ? [3, 4] : [2, 3, 4, 8, 16]
 @on_device work_group_barrier(OpenCL.LOCAL_MEM_FENCE, OpenCL.memory_scope_work_group)
 @on_device work_group_barrier(OpenCL.LOCAL_MEM_FENCE, OpenCL.memory_scope_device)
 cl.memory_backend() isa cl.SVMBackend && @on_device work_group_barrier(OpenCL.LOCAL_MEM_FENCE, OpenCL.memory_scope_all_svm_devices)
-@on_device work_group_barrier(OpenCL.LOCAL_MEM_FENCE, OpenCL.memory_scope_sub_group)
+cl.sub_groups_supported(cl.device()) && @on_device work_group_barrier(OpenCL.LOCAL_MEM_FENCE, OpenCL.memory_scope_sub_group)
 
-# sub-group
-@on_device sub_group_barrier(OpenCL.LOCAL_MEM_FENCE)
-@on_device sub_group_barrier(OpenCL.GLOBAL_MEM_FENCE)
-@on_device sub_group_barrier(OpenCL.LOCAL_MEM_FENCE | OpenCL.GLOBAL_MEM_FENCE)
+# sub-group (only when the device supports subgroups)
+if cl.sub_groups_supported(cl.device())
+    @on_device sub_group_barrier(OpenCL.LOCAL_MEM_FENCE)
+    @on_device sub_group_barrier(OpenCL.GLOBAL_MEM_FENCE)
+    @on_device sub_group_barrier(OpenCL.LOCAL_MEM_FENCE | OpenCL.GLOBAL_MEM_FENCE)
+end
 end
 
 @testset "mem_fence" begin
@@ -202,7 +204,7 @@ function test_subgroup_kernel(results)
     return
 end
 
-@testset "Sub-groups" begin
+cl.sub_groups_supported(cl.device()) && @testset "Sub-groups" begin
     sg_size = cl.sub_group_size(cl.device())
 
     @testset "Indexing intrinsics" begin


### PR DESCRIPTION
Register the optional device features we care about (fp16, fp64, int64_atomics, subgroups, generic_address_space) and query them two ways: `device_features(dev)` host-side, and `has_feature(name)` device-side, which folds to a constant so a kernel can pick a path at compile time.

Use it to give the device RNG a per-work-item fallback when subgroups aren't available, and gate the direct subgroup tests on device support.