### PR TITLE
Report subgroup support in versioninfo

### DIFF
--- a/src/util.jl
+++ b/src/util.jl
@@ -133,6 +133,16 @@ function versioninfo(io::IO=stdout)
             if in("cl_khr_il_program", device.extensions)
                 push!(tags, "il")
             end
+            if cl.sub_groups_supported(device)
+                sg_tags = []
+                if in("cl_khr_subgroup_shuffle", device.extensions)
+                    push!(sg_tags, "shfl")
+                end
+                # if in("cl_khr_subgroup_ballot", device.extensions)
+                #     push!(sg_tags, "blt")
+                # end
+                push!(tags, "sg:"*join(sg_tags, "+"))
+            end
             ## render
             if !isempty(tags)
                 print(io, " (", join(tags, ", "), ")")

--- a/src/util.jl
+++ b/src/util.jl
@@ -93,10 +93,10 @@ function versioninfo(io::IO=stdout)
             print(io, "   · $(device.name)")
 
             # show a list of tags
-            tags = []
+            tags = String[]
             ## memory back-ends
             let
-                svm_tags = []
+                svm_tags = String[]
                 svm_caps = cl.svm_capabilities(device)
                 if svm_caps.coarse_grain_buffer
                     push!(svm_tags, "c")
@@ -107,7 +107,7 @@ function versioninfo(io::IO=stdout)
                 push!(tags, "svm:"*join(svm_tags, "+"))
             end
             if cl.usm_supported(device)
-                usm_tags = []
+                usm_tags = String[]
                 usm_caps = cl.usm_capabilities(device)
                 if usm_caps.host.access
                     push!(usm_tags, "h")
@@ -134,7 +134,7 @@ function versioninfo(io::IO=stdout)
                 push!(tags, "il")
             end
             if cl.sub_groups_supported(device)
-                sg_tags = []
+                sg_tags = String[]
                 if in("cl_khr_subgroup_shuffle", device.extensions)
                     push!(sg_tags, "shfl")
                 end


### PR DESCRIPTION
Also ballot to be uncommented once supported
```julia-repl
julia> using pocl_jll, OpenCL; OpenCL.versioninfo()
OpenCL.jl version 0.10.9

Toolchain:
 - Julia v1.12.6
 - OpenCL: 2024.10.24+1
 - SPIRV_LLVM_Backend: 22.1.7+2

Julia packages:
- GPUArrays: 11.5.8
- GPUCompiler: 1.22.7
- KernelAbstractions: 0.9.42
- LLVM: 9.10.0
- SPIRVIntrinsics: 1.0.1
- pocl_jll: 7.1.3+4

Available platforms: 1
 - Portable Computing Language
   OpenCL 3.0, PoCL 7.1  Apple, Release, RELOC, SPIR-V, LLVM 20.1.2jl, SLEEF, DISTRO, POCL_DEBUG
   · cpu (svm:c+f, usm:h+d, bda, fp64, il, sg:shfl)
```