### PR TITLE
Trim the CI matrix to hand-picked configurations.

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -26,7 +26,7 @@ steps:
   - group: "macos"
     key: "julia"
     steps:
-      - label: "{{matrix.julia}} macos"
+      - label: "{{matrix.julia}} macos - {{matrix.pocl}}"
         plugins:
           - JuliaCI/julia#v1:
               version: "{{matrix.julia}}"
@@ -42,13 +42,13 @@ steps:
             # against the registry, which has no SPIRVIntrinsics 1. Pkg.test
             # then carries the in-tree copy into the test sandbox.
             Pkg.develop(path="lib/intrinsics")
-            Pkg.add("pocl_jll")
+            Pkg.add("{{matrix.pocl}}_jll")
             Pkg.add("InteractiveUtils")
 
             println("+++ :julia: Running tests")
             using InteractiveUtils
             InteractiveUtils.versioninfo()
-            Pkg.test(; coverage=true, test_args=`--platform=pocl`)'
+            Pkg.test(; coverage=true, test_args=`--platform={{matrix.pocl}}`)'
         agents:
           queue: "metal"
         if: build.message !~ /\[skip tests\]/
@@ -58,3 +58,12 @@ steps:
             julia:
               - "1.10"
               - "1.12"
+            pocl:
+              - "pocl"
+              - "pocl_next"
+          adjustments:
+            # the upcoming PoCL release is only smoke-tested on current Julia
+            - with:
+                julia: "1.10"
+                pocl: "pocl_next"
+              skip: true

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -21,23 +21,30 @@ jobs:
       contents: read
     strategy:
       fail-fast: false
+      # Hand-picked configurations instead of a full cross-product: the memory backend
+      # is a host-side, load-time preference that's essentially orthogonal to OS, arch,
+      # Julia version and PoCL build, so we cover all backends on the primary platform
+      # (Linux x64) and rotate them across the other platforms. The `pocl` axis selects
+      # the released JLL (`jll`), the upcoming release (`next`, via pocl_next_jll, run
+      # on every platform), or upstream PoCL HEAD built from source (`local`, one job,
+      # Linux-only).
       matrix:
-        version: ['1.10', '1.12']
-        os: [ubuntu-24.04, ubuntu-24.04-arm, windows-2022]
-        arch: [x64, arm64]
-        pocl: [jll, local]
-        memory_backend: [usm, svm, buffer]
-        exclude:
-          # unsupported combinations
-          - os: ubuntu-24.04
-            arch: arm64
-          - os: windows-2022
-            arch: arm64
-          - os: ubuntu-24.04-arm
-            arch: x64
-          # we only test building PoCL on Linux
-          - os: windows-2022
-            pocl: local
+        include:
+          # full memory-backend coverage on the primary platform
+          - { os: ubuntu-24.04, arch: x64, version: '1.12', pocl: jll, memory_backend: usm }
+          - { os: ubuntu-24.04, arch: x64, version: '1.12', pocl: jll, memory_backend: svm }
+          - { os: ubuntu-24.04, arch: x64, version: '1.12', pocl: jll, memory_backend: buffer }
+          # oldest supported Julia
+          - { os: ubuntu-24.04, arch: x64, version: '1.10', pocl: jll, memory_backend: usm }
+          # other platforms, one job each (backends rotated for extra cross-coverage)
+          - { os: ubuntu-24.04-arm, arch: arm64, version: '1.12', pocl: jll, memory_backend: svm }
+          - { os: windows-2022, arch: x64, version: '1.12', pocl: jll, memory_backend: usm }
+          # upcoming PoCL release (pocl_next_jll) on every platform
+          - { os: ubuntu-24.04, arch: x64, version: '1.12', pocl: next, memory_backend: usm }
+          - { os: ubuntu-24.04-arm, arch: arm64, version: '1.12', pocl: next, memory_backend: svm }
+          - { os: windows-2022, arch: x64, version: '1.12', pocl: next, memory_backend: buffer }
+          # upstream PoCL HEAD, built from source
+          - { os: ubuntu-24.04, arch: x64, version: '1.12', pocl: local, memory_backend: usm }
     steps:
       - name: Checkout OpenCL.jl
         uses: actions/checkout@v7
@@ -134,7 +141,7 @@ jobs:
         uses: julia-actions/julia-runtest@v1
         if: runner.os != 'Windows'
         with:
-          test_args: '--quickfail --verbose --platform=pocl'
+          test_args: "--quickfail --verbose --platform=${{ matrix.pocl == 'next' && 'pocl_next' || 'pocl' }}"
 
       - name: Setup BusyBox
         if: runner.os == 'Windows'
@@ -146,7 +153,7 @@ jobs:
         run: |
           using Pkg
           Pkg.activate(".")
-          Pkg.test(; test_args=`--quickfail --verbose --platform=pocl`)
+          Pkg.test(; test_args=`--quickfail --verbose --platform=${{ matrix.pocl == 'next' && 'pocl_next' || 'pocl' }}`)
 
       - name: Upload compilation dumps
         if: always()
@@ -155,56 +162,6 @@ jobs:
           name: compilation-dumps-${{ matrix.version }}-${{ matrix.os }}-${{ matrix.arch }}-${{ matrix.memory_backend }}-pocl-${{ matrix.pocl }}
           path: ${{ runner.temp }}/opencl-compilation-dumps/
           if-no-files-found: ignore
-
-      - uses: julia-actions/julia-processcoverage@v1
-      - uses: codecov/codecov-action@v7
-        with:
-          token: ${{ secrets.CODECOV_TOKEN }}
-          files: lcov.info
-
-  # Smoke-test against the upcoming PoCL release (pocl_next_jll) so we catch
-  # regressions early. This mirrors the `pocl: jll` path above but swaps in
-  # pocl_next via `--platform=pocl_next`, on a single representative
-  # configuration (rather than the full matrix) to keep it cheap.
-  test-pocl-next:
-    name: Julia ${{ matrix.version }} - PoCL next - ${{ matrix.memory_backend }}
-    runs-on: ubuntu-24.04
-    timeout-minutes: 100
-    permissions: # needed to allow julia-actions/cache to proactively delete old caches that it has created
-      actions: write
-      contents: read
-    strategy:
-      fail-fast: false
-      matrix:
-        version: ['1.12']
-        memory_backend: [usm, svm, buffer]
-    steps:
-      - name: Checkout OpenCL.jl
-        uses: actions/checkout@v7
-
-      - name: Setup Julia
-        uses: julia-actions/setup-julia@v3
-        with:
-          version: ${{ matrix.version }}
-          arch: x64
-
-      - name: Setup Julia cache
-        uses: julia-actions/cache@v3
-
-      - name: Setup OpenCL.jl
-        run: |
-          echo '[OpenCL]' >> test/LocalPreferences.toml
-          echo 'default_memory_backend="${{ matrix.memory_backend }}"' >> test/LocalPreferences.toml
-          julia --project -e '
-            using Pkg
-            # Julia 1.10 does not support [sources], so dev the in-tree
-            # SPIRVIntrinsics; Pkg.test then carries it into the test sandbox.
-            Pkg.develop(path="lib/intrinsics")'
-
-      - name: Test OpenCL.jl
-        uses: julia-actions/julia-runtest@v1
-        with:
-          test_args: '--quickfail --verbose --platform=pocl_next'
 
       - uses: julia-actions/julia-processcoverage@v1
       - uses: codecov/codecov-action@v7

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -36,6 +36,9 @@ jobs:
           - { os: ubuntu-24.04, arch: x64, version: '1.12', pocl: jll, memory_backend: buffer }
           # oldest supported Julia
           - { os: ubuntu-24.04, arch: x64, version: '1.10', pocl: jll, memory_backend: usm }
+          # Julia version coverage on the primary platform
+          - { os: ubuntu-24.04, arch: x64, version: '1.11', pocl: jll, memory_backend: usm }
+          - { os: ubuntu-24.04, arch: x64, version: '1.13-nightly', pocl: jll, memory_backend: usm }
           # other platforms, one job each (backends rotated for extra cross-coverage)
           - { os: ubuntu-24.04-arm, arch: arm64, version: '1.12', pocl: jll, memory_backend: svm }
           - { os: windows-2022, arch: x64, version: '1.12', pocl: jll, memory_backend: usm }

--- a/.github/workflows/Test.yml
+++ b/.github/workflows/Test.yml
@@ -144,7 +144,7 @@ jobs:
         uses: julia-actions/julia-runtest@v1
         if: runner.os != 'Windows'
         with:
-          test_args: "--quickfail --verbose --platform=${{ matrix.pocl == 'next' && 'pocl_next' || 'pocl' }}"
+          test_args: "--quickfail --verbose --platform=${{ case(matrix.pocl == 'next', 'pocl_next', 'pocl') }}"
 
       - name: Setup BusyBox
         if: runner.os == 'Windows'


### PR DESCRIPTION
Instead of crossing all memory backends with all platforms, Julia versions, and PoCL builds (33 jobs, ~1000 runner-minutes), run 10 hand-picked configurations: the memory backend is a host-side, load-time preference that is essentially orthogonal to the other axes, so cover all backends on Linux x64 and rotate them across the other platforms. The from-source PoCL build (upstream HEAD) is reduced to a single job, and the separate pocl_next smoke-test job is folded into the main matrix as a `pocl: next` axis value, now covering every platform rather than just Linux x64.

Closes https://github.com/JuliaGPU/OpenCL.jl/issues/366