### PR TITLE
handle missing vendor info in OpenCL version string gracefully

### DIFF
--- a/lib/cl/device.jl
+++ b/lib/cl/device.jl
@@ -17,7 +17,7 @@ end
 
 @inline function Base.getproperty(d::Device, s::Symbol)
     # simple string properties
-    version_re = r"OpenCL (?<major>\d+)\.(?<minor>\d+)(?<vendor>.+)"
+    version_re = r"OpenCL (?<major>\d+)\.(?<minor>\d+)(?<vendor>.*)"
     @inline function get_string(prop)
         sz = Ref{Csize_t}()
         clGetDeviceInfo(d, prop, 0, C_NULL, sz)


### PR DESCRIPTION
On my laptop, XRT advertises the NPU via OpenCL, but the version returned by the query is just `"OpenCL 1.0"` without any vendor info. Handle that case gracefully so at least `OpenCL.versioninfo()` doesn't error