### PR TITLE
Add partial workgroup local-memory regression

### DIFF
--- a/test/execution.jl
+++ b/test/execution.jl
@@ -1,5 +1,6 @@
 using SPIRV_LLVM_Translator_jll
 using IOCapture
+using KernelAbstractions
 
 @testset "@opencl" begin
 
@@ -114,6 +115,35 @@ a = CLArray{Int}(undef, 10)
 @opencl global_size=length(a) memset(a, 42)
 @test all(Array(a) .== 42)
 
+end
+
+@kernel cpu=false function partial_workgroup_localmem!(out, pred, @Const(v))
+    temp = @localmem Int8 (1,)
+    i = @index(Global, Linear)
+
+    temp[1] = 0
+    @synchronize()
+
+    if pred(v[i])
+        temp[1] = 1
+    end
+
+    @synchronize()
+    if temp[1] != 0
+        out[1] = 1
+    end
+end
+
+@testset "partial workgroup local memory" begin
+    backend = OpenCLBackend()
+    v = CLArray(zeros(Float32, 16))
+
+    for _ in 1:10
+        out = KernelAbstractions.zeros(backend, Int8, 1)
+        partial_workgroup_localmem!(backend, 256)(out, x -> x < 0, v; ndrange=length(v))
+        KernelAbstractions.synchronize(backend)
+        @test only(Array(out)) == 0
+    end
 end
 
 @testset "broadcasting" begin


### PR DESCRIPTION
Distilled from @christiangnrd's MWE:

```julia
# MWE: a KernelAbstractions kernel that resets a workgroup-shared @localmem
# cell, conditionally writes to it, and reads it back across two
# @synchronize() barriers returns a wrong result on PoCL when the launched
# workgroup is only partially active (ndrange not a multiple of block_size).
#
# Depends only on OpenCL, pocl_jll (or pocl_next_jll), KernelAbstractions.
#
# See pocl_localmem_barrier_bug_report.md for the full writeup, ruled-out
# causes, and links to related upstream pocl/pocl issues.
#
# Trigger conditions:
#   - the kernel must NOT suppress bounds checking on `v[i]` (this reproducer
#     intentionally omits `@inbounds`/`inbounds=true`, so it fails under
#     Julia's default `--check-bounds=auto`; adding `inbounds=true` to the
#     `@kernel` declaration makes it pass every time)
#   - `ndrange` (here 16) must not be a multiple of the static workgroup
#     size (here 256), so only some launched threads are "active"
#   - PoCL's default work-group codegen ("loopvec") is used; setting
#     `POCL_WORK_GROUP_METHOD=cbs` in the environment avoids the bug entirely
#
# Expected output: failures: 0 / 100 (expected 0)
# Actual output:   failures: ~50-98 / 100 (expected 0), depending on PoCL version

# using pocl_jll, OpenCL, KernelAbstractions
using pocl_next_jll, OpenCL, KernelAbstractions

@kernel cpu=false function reduce_any!(out, pred, @Const(v))
    temp = @localmem Int8 (1,)
    i = @index(Global, Linear)

    temp[0x1] = 0x0
    @synchronize()

    if pred(v[i])
        temp[0x1] = 0x1
    end

    @synchronize()
    if temp[0x1] != 0x0
        out[0x1] = 0x1
    end
end

backend = OpenCLBackend()
block_size = 256
n = 16              # not a multiple of block_size -> only 16/256 threads active

function main()
    fails = 0
    trials = 100
    for _ in 1:trials
        v = CLArray(zeros(Float32, n))          # all-zero: `x < 0` is false for every element
        out = KernelAbstractions.zeros(backend, Int8, 1)
        reduce_any!(backend, block_size)(out, x -> x < 0, v, ndrange=n)
        KernelAbstractions.synchronize(backend)
        Array(out)[1] != 0 && (fails += 1)
    end
    println("failures: $fails / $trials (expected 0)")
end

main()
```