### PR TITLE
Update version to 0.10.10

### DIFF
--- a/.buildkite/pipeline.yml
+++ b/.buildkite/pipeline.yml
@@ -48,7 +48,7 @@ steps:
             println("+++ :julia: Running tests")
             using InteractiveUtils
             InteractiveUtils.versioninfo()
-            Pkg.test(; coverage=true, test_args=`--platform={{matrix.pocl}}`)'
+            Pkg.test(; coverage=true, test_args=`--platform={{matrix.pocl}} --verbose`)'
         agents:
           queue: "metal"
         if: build.message !~ /\[skip tests\]/

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "OpenCL"
 uuid = "08131aa3-fb12-5dee-8b74-c09406e224a2"
-version = "0.10.9"
+version = "0.10.10"
 
 [workspace]
 projects = ["lib/intrinsics", "test", "docs", "res"]

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -203,4 +203,7 @@ function test_worker(_, init_worker_code)
     end
 end
 
-runtests(OpenCL, args; testsuite, init_code, init_worker_code, test_worker)
+# 8GB mac minis can struggle in some julia versions
+max_worker_rss = 2^20 * (Sys.total_memory() > 8*2^30 ? 3800 : 2200)
+
+runtests(OpenCL, args; testsuite, init_code, init_worker_code, test_worker, max_worker_rss)


### PR DESCRIPTION
Was released in a separate branch.

Add verbose because test durations and listed runtimes are a bit suspicious