### PR TITLE
Thread safety fixes

### DIFF
--- a/lib/cl/kernel.jl
+++ b/lib/cl/kernel.jl
@@ -7,14 +7,19 @@ export clcall
 
 mutable struct Kernel <: CLObject
     const id::cl_kernel
+    const lock::ReentrantLock
 
     function Kernel(k::cl_kernel, retain::Bool=false)
-        kernel = new(k)
+        kernel = new(k, ReentrantLock())
         retain && clRetainKernel(kernel)
         finalizer(clReleaseKernel, kernel)
         return kernel
     end
 end
+
+Base.lock(k::Kernel) = lock(getfield(k, :lock))
+Base.lock(f::Function, k::Kernel) = lock(f, getfield(k, :lock))
+Base.unlock(k::Kernel) = unlock(getfield(k, :lock))
 
 Base.unsafe_convert(::Type{cl_kernel}, k::Kernel) = k.id
 
@@ -261,6 +266,7 @@ function call(
         indirect_memory::Vector{AbstractMemory} = AbstractMemory[],
         rng_state=false,
     )
+    return Base.@lock k begin
     set_args!(k, args...)
     if !isempty(indirect_memory)
         svm_pointers = CLPtr{Cvoid}[]
@@ -313,7 +319,9 @@ function call(
             clSetKernelExecInfo(k, CL_KERNEL_EXEC_INFO_USM_PTRS_INTEL, sizeof(usm_pointers), usm_pointers)
         end
     end
-    enqueue_kernel(k, global_size, local_size; global_work_offset, wait_on, rng_state, nargs=length(args))
+    enqueue_kernel(k, global_size, local_size; global_work_offset, wait_on, rng_state,
+                   nargs=length(args))
+    end
 end
 
 # From `julia/base/reflection.jl`, adjusted to add specialization on `t`.
@@ -336,6 +344,14 @@ function _to_tuple_type(t)
     t
 end
 
+"""
+    clcall(kernel, types, args...; kwargs...)
+
+Set the arguments of `kernel` and enqueue it as one atomic operation with respect to other
+uses of the same kernel object. Manual use of `cl.set_arg!`, `cl.set_args!`, or
+`cl.enqueue_kernel` is not internally synchronized; hold `lock(kernel)` across the complete
+argument-setup and enqueue sequence.
+"""
 clcall(f::F, types::Tuple, args::Vararg{Any,N}; kwargs...) where {N,F} =
     clcall(f, _to_tuple_type(types), args...; kwargs...)
 

--- a/lib/cl/kernel.jl
+++ b/lib/cl/kernel.jl
@@ -362,33 +362,53 @@ function clcall(k::Kernel, types::Type{T}, args::Vararg{Any,N}; kwargs...) where
     convert_arguments(call_closure, types, args...)
 end
 
-
 ## generic argument conversion
 
 # convert the argument values to match the kernel's signature (specified by the user)
 # (this mimics `lower-ccall` in julia-syntax.scm)
 clconvert(typ, arg) = Base.cconvert(typ, arg)
 unsafe_clconvert(typ, arg) = Base.unsafe_convert(typ, arg)
+argument_lock(arg) = nothing
+
+function lock_arguments(args...)
+    locks = unique(filter(!isnothing, map(argument_lock, args)))
+    sort!(locks; by=objectid)
+    foreach(lock, locks)
+    return locks
+end
+
+unlock_arguments(locks) = foreach(unlock, Iterators.reverse(locks))
+
 @inline @generated function convert_arguments(f::Function, ::Type{tt}, args...) where {tt}
-    types = tt.parameters
-
     ex = quote end
-
     converted_args = Vector{Symbol}(undef, length(args))
     arg_ptrs = Vector{Symbol}(undef, length(args))
     for i in 1:length(args)
         converted_args[i] = gensym()
         arg_ptrs[i] = gensym()
-        push!(ex.args, :($(converted_args[i]) = clconvert($(types[i]), args[$i])))
-        push!(ex.args, :($(arg_ptrs[i]) = unsafe_clconvert($(types[i]), $(converted_args[i]))))
+        push!(ex.args, :($(converted_args[i]) = clconvert($(tt.parameters[i]), args[$i])))
     end
 
-    append!(ex.args, (quote
+    locked = gensym()
+    push!(ex.args, :($locked = lock_arguments($(converted_args...))))
+    body = quote end
+    for i in 1:length(args)
+        push!(body.args,
+              :($(arg_ptrs[i]) = unsafe_clconvert($(tt.parameters[i]), $(converted_args[i]))))
+    end
+
+    append!(body.args, (quote
         GC.@preserve $(converted_args...) begin
             f($(arg_ptrs...))
         end
     end).args)
-
+    push!(ex.args, quote
+        try
+            $body
+        finally
+            unlock_arguments($locked)
+        end
+    end)
     return ex
 end
 

--- a/src/array.jl
+++ b/src/array.jl
@@ -273,12 +273,16 @@ Base.convert(::Type{T}, x::T) where {T <: CLArray} = x
 
 function Base.getindex(x::CLArray{<:Any, <:Any, <:Union{cl.UnifiedHostMemory, cl.UnifiedSharedMemory, cl.SharedVirtualMemory}}, I::Int)
     @boundscheck checkbounds(x, I)
-    return GC.@preserve x unsafe_load(host_pointer(x, I))
+    return Base.@lock x.data[].lock begin
+        GC.@preserve x unsafe_load(host_pointer(x, I))
+    end
 end
 
 function Base.setindex!(x::CLArray{<:Any, <:Any, <:Union{cl.UnifiedHostMemory, cl.UnifiedSharedMemory, cl.SharedVirtualMemory}}, v, I::Int)
     @boundscheck checkbounds(x, I)
-    return GC.@preserve x unsafe_store!(host_pointer(x, I), v)
+    return Base.@lock x.data[].lock begin
+        GC.@preserve x unsafe_store!(host_pointer(x, I), v)
+    end
 end
 
 
@@ -298,10 +302,20 @@ function Base.unsafe_convert(::Type{CLPtr{T}}, x::CLArray{T}) where {T}
     return convert(CLPtr{T}, x.data[]) + x.offset
 end
 
-# when passing to OpenCL kernels with `clcall`, don't convert directly to a pointer,
-# but keep the underlying memory around so that we can configure the kernel correctly.
-function cl.clconvert(::Type{<:Union{Ptr, CLPtr}}, x::CLArray)
+# when passing to OpenCL kernels with `clcall`, don't convert directly to a pointer, but
+# to the array itself: `convert_arguments` keeps the converted values alive and locked
+# through enqueue, so returning the owner both preserves the `DataRef` (preventing
+# finalization of the allocation mid-launch) and carries the allocation lock.
+# the pointer is only extracted by `unsafe_clconvert`, under that lock.
+cl.clconvert(::Type{<:Union{Ptr, CLPtr}}, x::CLArray) = x
+cl.argument_lock(x::CLArray) = x.data[].lock
+function cl.unsafe_clconvert(typ::Type{<:Union{Ptr, CLPtr}}, x::CLArray{<:Any, <:Any, <:cl.AbstractMemoryObject})
+    device_convert(cl.Buffer, x.data[])
     return x.data[].mem
+end
+function cl.unsafe_clconvert(typ::Type{<:Union{Ptr{T}, CLPtr{T}}}, x::CLArray{<:Any, <:Any, M}) where {T,M<:cl.AbstractPointerMemory}
+    ptr = device_convert(typ, x.data[])
+    return cl.TrackedPtr{T,M}(ptr)
 end
 
 
@@ -389,26 +403,31 @@ for (srcty, dstty) in [(:Array, :CLArray), (:CLArray, :Array), (:CLArray, :CLArr
 
             device_array = $dstty == CLArray ? dst : src
             cl.context!(context(device_array)) do
-                if memtype(device_array) == cl.SharedVirtualMemory
-                    cl.enqueue_svm_copy(pointer(dst, dst_off), pointer(src, src_off), nbytes; blocking)
-                elseif memtype(device_array) <: cl.UnifiedMemory
-                    cl.enqueue_usm_copy(pointer(dst, dst_off), pointer(src, src_off), nbytes; blocking)
-                else
-                    if src isa CLArray && dst isa CLArray
-                        cl.enqueue_copy(convert(cl.Buffer, dst.data[]),
-                            dst.offset + (dst_off - 1) * sizeof(T),
-                            convert(cl.Buffer, src.data[]),
-                            src.offset + (src_off - 1) * sizeof(T),
-                            nbytes; blocking)
-                    elseif dst isa CLArray
-                        cl.enqueue_write(convert(cl.Buffer, dst.data[]),
-                            dst.offset + (dst_off - 1) * sizeof(T),
-                            pointer(src, src_off), nbytes; blocking)
-                    elseif src isa CLArray
-                        cl.enqueue_read(pointer(dst, dst_off),
-                            convert(cl.Buffer, src.data[]),
-                            src.offset + (src_off - 1) * sizeof(T),
-                            nbytes; blocking)
+                managed = Managed[]
+                dst isa CLArray && push!(managed, dst.data[])
+                src isa CLArray && push!(managed, src.data[])
+                with_managed_locks(managed) do
+                    if memtype(device_array) == cl.SharedVirtualMemory
+                        cl.enqueue_svm_copy(pointer(dst, dst_off), pointer(src, src_off), nbytes; blocking)
+                    elseif memtype(device_array) <: cl.UnifiedMemory
+                        cl.enqueue_usm_copy(pointer(dst, dst_off), pointer(src, src_off), nbytes; blocking)
+                    else
+                        if src isa CLArray && dst isa CLArray
+                            cl.enqueue_copy(convert(cl.Buffer, dst.data[]),
+                                dst.offset + (dst_off - 1) * sizeof(T),
+                                convert(cl.Buffer, src.data[]),
+                                src.offset + (src_off - 1) * sizeof(T),
+                                nbytes; blocking)
+                        elseif dst isa CLArray
+                            cl.enqueue_write(convert(cl.Buffer, dst.data[]),
+                                dst.offset + (dst_off - 1) * sizeof(T),
+                                pointer(src, src_off), nbytes; blocking)
+                        elseif src isa CLArray
+                            cl.enqueue_read(pointer(dst, dst_off),
+                                convert(cl.Buffer, src.data[]),
+                                src.offset + (src_off - 1) * sizeof(T),
+                                nbytes; blocking)
+                        end
                     end
                 end
             end
@@ -448,13 +467,15 @@ fill(v, dims::Dims) = fill!(CLArray{typeof(v)}(undef, dims...), v)
 function Base.fill!(A::DenseCLArray{T}, val) where {T}
     isempty(A) && return A
     cl.context!(context(A)) do
-        GC.@preserve A begin
-            if memtype(A) == cl.SharedVirtualMemory
-                cl.enqueue_svm_fill(pointer(A), convert(T, val), length(A))
-            elseif memtype(A) <: cl.UnifiedMemory
-                cl.enqueue_usm_fill(pointer(A), convert(T, val), length(A))
-            else
-                cl.enqueue_fill(convert(cl.Buffer, A.data[]), A.offset, convert(T, val), length(A))
+        Base.@lock A.data[].lock begin
+            GC.@preserve A begin
+                if memtype(A) == cl.SharedVirtualMemory
+                    cl.enqueue_svm_fill(pointer(A), convert(T, val), length(A))
+                elseif memtype(A) <: cl.UnifiedMemory
+                    cl.enqueue_usm_fill(pointer(A), convert(T, val), length(A))
+                else
+                    cl.enqueue_fill(convert(cl.Buffer, A.data[]), A.offset, convert(T, val), length(A))
+                end
             end
         end
     end
@@ -524,16 +545,18 @@ function Base.resize!(a::CLVector{T}, n::Integer) where {T}
     # as a result, we can safely support resizing unowned buffers.
     new_data = cl.context!(context(a)) do
         mem = managed_alloc(memtype(a), bufsize; alignment=Base.datatype_alignment(T))
-        ptr = convert(CLPtr{T}, mem)
-        m = min(length(a), n)
-        if m > 0
-            GC.@preserve a begin
-                if memtype(a) == cl.SharedVirtualMemory
-                    cl.enqueue_svm_copy(ptr, pointer(a), m*sizeof(T); blocking=false)
-                elseif memtype(a) <: cl.UnifiedMemory
-                    cl.enqueue_usm_copy(ptr, pointer(a), m*sizeof(T); blocking=false)
-                else
-                    cl.enqueue_copy(convert(cl.Buffer, mem), 0, convert(cl.Buffer, a.data[]), a.offset, m*sizeof(T); blocking=false)
+        with_managed_locks(Managed[mem, a.data[]]) do
+            ptr = convert(CLPtr{T}, mem)
+            m = min(length(a), n)
+            if m > 0
+                GC.@preserve a begin
+                    if memtype(a) == cl.SharedVirtualMemory
+                        cl.enqueue_svm_copy(ptr, pointer(a), m*sizeof(T); blocking=false)
+                    elseif memtype(a) <: cl.UnifiedMemory
+                        cl.enqueue_usm_copy(ptr, pointer(a), m*sizeof(T); blocking=false)
+                    else
+                        cl.enqueue_copy(convert(cl.Buffer, mem), 0, convert(cl.Buffer, a.data[]), a.offset, m*sizeof(T); blocking=false)
+                    end
                 end
             end
         end

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -156,16 +156,16 @@ end
 # cache of compiler configurations, per device (but additionally configurable via kwargs)
 const _toolchain = Ref{Any}()
 const _compiler_configs = Dict{UInt, OpenCLCompilerConfig}()
+const compiler_config_lock = ReentrantLock()
 function compiler_config(dev::cl.Device; kwargs...)
     # key on the policy, not the resolved backend: resolving queries the device, so defer it to link
     backend = program_backend()
     h = hash(dev, hash(backend, hash(kwargs)))
-    config = get(_compiler_configs, h, nothing)
-    if config === nothing
-        config = _compiler_config(dev, backend; kwargs...)
-        _compiler_configs[h] = config
+    return Base.@lock compiler_config_lock begin
+        get!(_compiler_configs, h) do
+            _compiler_config(dev, backend; kwargs...)
+        end
     end
-    return config
 end
 @inline _sub_group_size(dev) = "cl_intel_required_subgroup_size" in dev.extensions ? cl.sub_group_size(dev) : nothing
 

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -81,7 +81,10 @@ end
 ## argument conversion
 
 struct KernelAdaptor
+    # memory objects to pass to `clSetKernelExecInfo` for indirect access
     indirect_memory::Vector{cl.AbstractMemory}
+    # managed allocations whose ownership needs to be established at launch
+    managed::Vector{Managed}
 end
 
 # when converting to pointers, we need to keep track of the underlying memory type
@@ -91,8 +94,16 @@ function Adapt.adapt_storage(to::KernelAdaptor, buf::cl.AbstractMemory)
     return ptr
 end
 function Adapt.adapt_storage(to::KernelAdaptor, arr::CLArray{T, N}) where {T, N}
-    push!(to.indirect_memory, arr.data[].mem)
-    return Base.unsafe_convert(CLDeviceArray{T, N, AS.CrossWorkgroup}, arr)
+    managed = arr.data[]
+    push!(to.indirect_memory, managed.mem)
+    push!(to.managed, managed)
+    # note that conversion is pure: it does not migrate ownership of the allocation,
+    # which only happens as part of the launch transaction (`take_ownership!`), under
+    # the allocation lock and atomically with the enqueue of the kernel.
+    ptr = convert(CLPtr{T}, managed.mem) + arr.offset
+    return CLDeviceArray{T, N, AS.CrossWorkgroup}(
+        size(arr), reinterpret(LLVMPtr{T, AS.CrossWorkgroup}, ptr),
+        arr.maxsize - arr.offset)
 end
 
 # Base.RefValue isn't GPU compatible, so provide a compatible alternative
@@ -125,8 +136,9 @@ input object `x` as-is.
 Do not add methods to this function, but instead extend the underlying Adapt.jl package and
 register methods for the the `OpenCL.KernelAdaptor` type.
 """
-kernel_convert(arg, indirect_memory::Vector{cl.AbstractMemory} = cl.AbstractMemory[]) =
-    adapt(KernelAdaptor(indirect_memory), arg)
+kernel_convert(arg, indirect_memory::Vector{cl.AbstractMemory} = cl.AbstractMemory[],
+               managed::Vector{Managed} = Managed[]) =
+    adapt(KernelAdaptor(indirect_memory, managed), arg)
 
 ## abstract kernel functionality
 
@@ -137,7 +149,7 @@ pass_arg(@nospecialize dt) = !(isghosttype(dt) || Core.Compiler.isconstType(dt))
 @inline @generated function (kernel::AbstractKernel{F,TT})(args...;
                                                            call_kwargs...) where {F,TT}
     sig = Tuple{F, TT.parameters...}    # Base.signature_type with a function type
-    args = (:(kernel.f), (:(kernel_convert(args[$i], indirect_memory)) for i in 1:length(args))...)
+    args = (:(kernel.f), (:(kernel_convert(args[$i], indirect_memory, managed)) for i in 1:length(args))...)
 
     # filter out ghost arguments that shouldn't be passed
     to_pass = map(pass_arg, sig.parameters)
@@ -155,12 +167,28 @@ pass_arg(@nospecialize dt) = !(isghosttype(dt) || Core.Compiler.isconstType(dt))
     pushfirst!(call_t, KernelState)
     pushfirst!(call_args, :(KernelState(kernel.rng_state ? Base.rand(UInt32) : UInt32(0))))
 
-    # finalize types
-    call_tt = Base.to_tuple_type(call_t)
-
+    # convert arguments before locking (conversion is pure, and collects the managed
+    # allocations to lock), then perform the launch transaction: with all participating
+    # allocations locked in stable order, migrate their queue ownership and enqueue the
+    # kernel. the original arguments are preserved throughout, keeping the converted
+    # pointers valid: neither the converted values nor the collected `Managed` objects
+    # retain the `DataRef` ownership of their allocation.
+    converted = [gensym(:arg) for _ in call_args]
+    conversions = [:($(converted[i]) = $(call_args[i])) for i in 1:length(call_args)]
     quote
         indirect_memory = cl.AbstractMemory[]
-        clcall(kernel.fun, $call_tt, $(call_args...); indirect_memory, kernel.rng_state, call_kwargs...)
+        managed = Managed[]
+        GC.@preserve args begin
+            $(conversions...)
+            locked = lock_managed(managed)
+            try
+                foreach(take_ownership!, locked)
+                cl.call(kernel.fun, $(converted...);
+                        indirect_memory, kernel.rng_state, call_kwargs...)
+            finally
+                unlock_managed(locked)
+            end
+        end
     end
 end
 

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -63,7 +63,8 @@ macro opencl(ex...)
                 $kernel_f = $kernel_convert($f_var)
                 $kernel_args = map($kernel_convert, ($(var_exprs...),))
                 $kernel_tt = Tuple{map(Core.Typeof, $kernel_args)...}
-                $kernel = $clfunction($kernel_f, $kernel_tt; $(compiler_kwargs...))
+                $kernel = $clfunction($kernel_f, $kernel_tt;
+                                      source=$f_var, $(compiler_kwargs...))
                 if $launch
                     $kernel($(var_exprs...); $(call_kwargs...))
                 end
@@ -149,7 +150,8 @@ pass_arg(@nospecialize dt) = !(isghosttype(dt) || Core.Compiler.isconstType(dt))
 @inline @generated function (kernel::AbstractKernel{F,TT})(args...;
                                                            call_kwargs...) where {F,TT}
     sig = Tuple{F, TT.parameters...}    # Base.signature_type with a function type
-    args = (:(kernel.f), (:(kernel_convert(args[$i], indirect_memory, managed)) for i in 1:length(args))...)
+    args = (:(kernel_convert(source, indirect_memory, managed)),
+            (:(kernel_convert(args[$i], indirect_memory, managed)) for i in 1:length(args))...)
 
     # filter out ghost arguments that shouldn't be passed
     to_pass = map(pass_arg, sig.parameters)
@@ -170,15 +172,16 @@ pass_arg(@nospecialize dt) = !(isghosttype(dt) || Core.Compiler.isconstType(dt))
     # convert arguments before locking (conversion is pure, and collects the managed
     # allocations to lock), then perform the launch transaction: with all participating
     # allocations locked in stable order, migrate their queue ownership and enqueue the
-    # kernel. the original arguments are preserved throughout, keeping the converted
-    # pointers valid: neither the converted values nor the collected `Managed` objects
-    # retain the `DataRef` ownership of their allocation.
+    # kernel. the source callable and arguments are preserved throughout, keeping the
+    # converted pointers valid: neither the converted values nor the collected `Managed`
+    # objects retain the `DataRef` ownership of their allocation.
     converted = [gensym(:arg) for _ in call_args]
     conversions = [:($(converted[i]) = $(call_args[i])) for i in 1:length(call_args)]
     quote
         indirect_memory = cl.AbstractMemory[]
         managed = Managed[]
-        GC.@preserve args begin
+        source = kernel.source
+        GC.@preserve source args begin
             $(conversions...)
             locked = lock_managed(managed)
             try
@@ -196,8 +199,9 @@ end
 
 ## host-side kernels
 
-struct HostKernel{F,TT} <: AbstractKernel{F,TT}
+struct HostKernel{F,S,TT} <: AbstractKernel{F,TT}
     f::F
+    source::S
     fun::cl.Kernel
     rng_state::Bool
 end
@@ -207,11 +211,11 @@ end
 
 const clfunction_lock = ReentrantLock()
 
-function clfunction(f::F, tt::TT=Tuple{}; kwargs...) where {F,TT}
+function clfunction(f::F, tt::TT=Tuple{}; source=f, kwargs...) where {F,TT}
     Base.@lock clfunction_lock begin
         config = compiler_config(cl.device(); kwargs...)::OpenCLCompilerConfig
-        source = methodinstance(F, tt)
-        job = CompilerJob(source, config)
+        mi = methodinstance(F, tt)
+        job = CompilerJob(mi, config)
 
         res = compile_or_lookup(job)::OpenCLResults
 
@@ -235,10 +239,7 @@ function clfunction(f::F, tt::TT=Tuple{}; kwargs...) where {F,TT}
             end
         end
 
-        h = hash(kernel, hash(f, hash(tt)))
-        get!(_kernel_instances, h) do
-            HostKernel{F,tt}(f, kernel, res.device_rng)
-        end::HostKernel{F,tt}
+        HostKernel{F,typeof(source),tt}(f, source, kernel, res.device_rng)
     end
 end
 
@@ -260,6 +261,3 @@ function compile_or_lookup(@nospecialize(job::CompilerJob))::OpenCLResults
     end
     return res
 end
-
-# cache of kernel instances
-const _kernel_instances = Dict{UInt, Any}()

--- a/src/gpuarrays.jl
+++ b/src/gpuarrays.jl
@@ -7,13 +7,17 @@ function GPUArrays.derive(::Type{T}, a::CLArray, dims::Dims{N}, offset::Int) whe
 end
 
 const GLOBAL_RNGs = Dict{cl.Device,GPUArrays.RNG}()
+const global_rngs_lock = ReentrantLock()
+
 function GPUArrays.default_rng(::Type{<:CLArray})
     dev = cl.device()
-    get!(GLOBAL_RNGs, dev) do
-        N = dev.max_work_group_size
-        state = CLArray{NTuple{4, UInt32}}(undef, N)
-        rng = GPUArrays.RNG(state)
-        Random.seed!(rng)
-        rng
+    return Base.@lock global_rngs_lock begin
+        get!(GLOBAL_RNGs, dev) do
+            N = dev.max_work_group_size
+            state = CLArray{NTuple{4, UInt32}}(undef, N)
+            rng = GPUArrays.RNG(state)
+            Random.seed!(rng)
+            rng
+        end
     end
 end

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -5,9 +5,9 @@
 # to safely use allocated memory across tasks and devices, we don't simply return raw
 # memory objects, but wrap them in a manager that ensures synchronization and ownership.
 
-# XXX: immutable with atomic refs?
 mutable struct Managed{M}
     const mem::M
+    const lock::ReentrantLock
 
     # which stream is currently using the memory.
     queue::cl.CmdQueue
@@ -23,27 +23,82 @@ mutable struct Managed{M}
         #       guaranteed to be physically allocated at a synchronization event.
         # NOTE: memory also starts as device-owned, because we need to map it as soon as
         #       the host accesses it.
-        return new{typeof(mem)}(mem, queue, dirty, user)
+        return new{typeof(mem)}(mem, ReentrantLock(), queue, dirty, user)
     end
 end
 
 Base.sizeof(managed::Managed) = sizeof(managed.mem)
 
-# wait for the current owner of memory to finish processing
-function synchronize(managed::Managed)
-    cl.finish(managed.queue)
-    managed.dirty = false
+function lock_managed(managed::AbstractVector{<:Managed})
+    locked = unique(managed)
+    sort!(locked; by=memory -> objectid(memory.lock))
+    for memory in locked
+        lock(memory.lock)
+    end
+    return locked
+end
+
+function unlock_managed(locked::AbstractVector{<:Managed})
+    for memory in Iterators.reverse(locked)
+        unlock(memory.lock)
+    end
     return
 end
 
-function maybe_synchronize(managed::Managed)
-    if managed.dirty
-        synchronize(managed)
+function with_managed_locks(f::F, managed::AbstractVector{<:Managed}) where {F}
+    locked = lock_managed(managed)
+    try
+        return f()
+    finally
+        unlock_managed(locked)
     end
-    return nothing
 end
 
-function Base.convert(typ::Union{Type{<:CLPtr}, Type{cl.Buffer}}, managed::Managed{M}) where {M}
+# wait for the current owner of memory to finish processing
+function synchronize(managed::Managed)
+    return Base.@lock managed.lock begin
+        cl.finish(managed.queue)
+        managed.dirty = false
+        nothing
+    end
+end
+
+function maybe_synchronize(managed::Managed)
+    return Base.@lock managed.lock begin
+        if managed.dirty
+            synchronize(managed)
+        end
+        nothing
+    end
+end
+
+# transfer queue ownership of an allocation, synchronizing the previous owner if needed,
+# and mark it dirty in anticipation of a device-side operation. the caller must hold
+# `managed.lock`, and keep holding it until that operation has been submitted to `queue`:
+# the recorded ownership describes the submitted operation, so another task may only
+# observe it together with the submission it describes.
+function take_ownership!(managed::Managed{M}; queue=cl.queue()) where {M}
+    sizeof(managed) == 0 && return managed
+
+    # accessing memory on another queue: ensure the data is ready and take ownership
+    if managed.queue != queue
+        managed.dirty && synchronize(managed)
+        managed.queue = queue
+    end
+
+    # coarse-grained SVM needs to be unmapped when accessing it back from the device
+    # TODO: support fine-grained SVM
+    if M == cl.SharedVirtualMemory && managed.user == :host
+        cl.enqueue_svm_unmap(pointer(managed.mem); queue)
+        managed.user = :device
+    end
+
+    managed.dirty = true
+    return managed
+end
+
+function device_convert(typ::Union{Type{<:CLPtr}, Type{cl.Buffer}},
+                        managed::Managed{M}) where {M}
     # let null pointers pass through as-is
     # XXX: does not work for buffers
     ptr = convert(typ, managed.mem)
@@ -51,22 +106,12 @@ function Base.convert(typ::Union{Type{<:CLPtr}, Type{cl.Buffer}}, managed::Manag
         return ptr
     end
 
-    # accessing memory on another queue: ensure the data is ready and take ownership
-    if managed.queue != cl.queue()
-        maybe_synchronize(managed)
-        managed.queue = cl.queue()
-    end
-
-    # coarse-grained SVM needs to be unmapped when accessing it back from the device
-    # TODO: support fine-grained SVM
-    if M == cl.SharedVirtualMemory && managed.user == :host
-        cl.enqueue_svm_unmap(pointer(managed.mem))
-        managed.user = :device
-    end
-
-    managed.dirty = true
+    take_ownership!(managed)
     return ptr
 end
+
+Base.convert(typ::Union{Type{<:CLPtr}, Type{cl.Buffer}}, managed::Managed) =
+    Base.@lock managed.lock device_convert(typ, managed)
 
 function Base.convert(typ::Type{<:Ptr}, managed::Managed{M}) where {M}
     # let null pointers pass through as-is
@@ -84,17 +129,19 @@ function Base.convert(typ::Type{<:Ptr}, managed::Managed{M}) where {M}
         )
     end
 
-    # make sure any work on the memory has finished.
-    maybe_synchronize(managed)
+    return Base.@lock managed.lock begin
+        # make sure any work on the memory has finished.
+        managed.dirty && synchronize(managed)
 
-    # coarse-grained SVM needs to be mapped when initially accessing it from the host
-    # TODO: support fine-grained SVM
-    if M == cl.SharedVirtualMemory && managed.user != :host
-        cl.enqueue_svm_map(pointer(managed.mem), sizeof(managed.mem), :rw; blocking = true)
-        managed.user = :host
+        # coarse-grained SVM needs to be mapped when initially accessing it from the host
+        # TODO: support fine-grained SVM
+        if M == cl.SharedVirtualMemory && managed.user != :host
+            cl.enqueue_svm_map(pointer(managed.mem), sizeof(managed.mem), :rw; blocking=true)
+            managed.user = :host
+        end
+
+        ptr
     end
-
-    return ptr
 end
 
 
@@ -170,8 +217,8 @@ end
 
 function free(managed::Managed)
     sizeof(managed) == 0 && return
-    mem = managed.mem
-    cl.context!(cl.context(mem)) do
+    return Base.@lock managed.lock begin
+        mem = managed.mem
         # "`clSVMFree` does not wait for previously enqueued commands that may be using
         # svm_pointer to finish before freeing svm_pointer. It is the responsibility of the
         # application to make sure that enqueued commands that use svm_pointer have finished
@@ -182,9 +229,11 @@ function free(managed::Managed)
         end
 
         if mem isa cl.SharedVirtualMemory
-            if managed.user == :host
-                # if the coarse-grained SVM buffer is mapped on the host, unmap it first.
-                cl.enqueue_svm_unmap(pointer(mem))
+            if managed.user == :host && managed.queue.valid
+                # Finalizers must not query or mutate task-local state, so use the queue owned by
+                # the allocation. Finish the unmap before releasing the SVM allocation.
+                cl.enqueue_svm_unmap(pointer(mem); queue=managed.queue)
+                cl.finish(managed.queue)
             end
             cl.svm_free(mem)
         elseif mem isa cl.UnifiedMemory
@@ -192,7 +241,7 @@ function free(managed::Managed)
         else
             cl.release(mem)
         end
-    end
 
-    return
+        nothing
+    end
 end

--- a/src/util.jl
+++ b/src/util.jl
@@ -20,15 +20,14 @@ function build_kernel(program::String, kernel_name::String; vars...)
     return cl.Kernel(p, kernel_name)
 end
 
-const CACHED_KERNELS = Dict{Any, cl.Kernel}()
+const cached_kernels = Dict{Any, cl.Kernel}()
+const cached_kernels_lock = ReentrantLock()
 function get_kernel(program_file::String, kernel_name::String; vars...)
     key = (cl.context(), program_file, kernel_name, Dict(vars))
-    if in(key, keys(CACHED_KERNELS))
-        return CACHED_KERNELS[key]
-    else
-        kernel = build_kernel(read(program_file, String), kernel_name; vars...)
-        CACHED_KERNELS[key] = kernel
-        return kernel
+    return Base.@lock cached_kernels_lock begin
+        get!(cached_kernels, key) do
+            build_kernel(read(program_file, String), kernel_name; vars...)
+        end
     end
 end
 

--- a/test/execution.jl
+++ b/test/execution.jl
@@ -2,6 +2,16 @@ using SPIRV_LLVM_Translator_jll
 using IOCapture
 using KernelAbstractions
 
+struct CapturedArray{A}
+    array::A
+end
+OpenCL.Adapt.@adapt_structure CapturedArray
+
+function (f::CapturedArray)()
+    @inbounds f.array[1] = 7
+    return
+end
+
 @testset "@opencl" begin
 
 dummy() = nothing
@@ -35,6 +45,25 @@ end
     k = @opencl launch=false dummy()
     k()
     k(; global_size=1)
+
+    function captured_kernel()
+        array = CLArray(Int32[0])
+        owner = WeakRef(array)
+        kernel = @opencl launch=false CapturedArray(array)()
+        return kernel, owner
+    end
+
+    kernel, owner = captured_kernel()
+    GC.gc(true)
+    @test owner.value !== nothing
+
+    queue = cl.CmdQueue()
+    cl.queue!(queue) do
+        kernel()
+        @test owner.value.data[].queue === queue
+        cl.finish(queue)
+    end
+    @test Array(owner.value) == Int32[7]
 end
 
 @testset "inference" begin


### PR DESCRIPTION
Improves thread safety by locking some operations. Annoyingly, `Managed` also needs to become transactional to protect against:

```text
Initial state: managed.queue = Q0, managed.dirty = true

Task A                                      Task B
------                                      ------
convert for Q1
  finish(Q0)
  managed.queue = Q1
  managed.dirty = true
return pointer
                                            convert for Q2
                                              finish(Q1)
                                              # Q1 is empty at this instant
                                              managed.queue = Q2
                                              managed.dirty = true
                                            return pointer
                                            enqueue operation B on Q2
enqueue operation A on Q1
```

`finish(Q1)` does not order operation A because A has not been submitted yet. Operations A
and B can consequently execute concurrently even though the `Managed` state claims that
ownership was transferred from Q1 to Q2. Later synchronization consults only the one queue
stored in `managed.queue`; it cannot reconstruct the missing ordering edge.