### PR TITLE
Report device-side exceptions at host synchronization

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -31,7 +31,7 @@ SPIRVIntrinsics = {path = "lib/intrinsics"}
 [compat]
 Adapt = "4"
 GPUArrays = "11.2.1"
-GPUCompiler = "2"
+GPUCompiler = "2.5.2"
 KernelAbstractions = "0.9.38"
 LLVM = "9.6"
 LinearAlgebra = "1"

--- a/docs/src/02-exceptions.md
+++ b/docs/src/02-exceptions.md
@@ -1,0 +1,64 @@
+# Device-side exceptions
+
+OpenCL kernels report device-side exceptions to the host as `KernelException`s. The
+faulting work-item exits, and the exception is raised at the next synchronization point:
+`cl.finish`, a blocking copy such as `Array(x)`, or `KernelAbstractions.synchronize`.
+
+```julia-repl
+julia> a = OpenCL.zeros(Float32, 1);
+
+julia> @opencl (a -> (a[2] = 1f0; return))(a)
+
+julia> cl.finish(cl.queue())
+ERROR: KernelException: A BoundsError was thrown on device cpu-...: Out-of-bounds array access
+For more details, run Julia with `-g2`, or launch the kernel with `@opencl debug_level=2`
+```
+
+The mailbox is reset before the host exception is thrown, so subsequent kernels can run
+normally. Results from a failed kernel may be incomplete. Exception handling does not relax
+OpenCL's requirements for convergent work-group barriers.
+
+## Diagnostic detail
+
+Kernels default to Julia's `-g` setting. Use `@opencl debug_level=N`, or the same keyword to
+`clfunction`, to select the amount of diagnostic information per kernel:
+
+- `0`: records only that an exception occurred.
+- `1` (the default): also records the type and reason for common runtime errors, including
+  bounds errors, domain errors, overflow, and inexact conversions.
+- `2`: also records the work-item's local id and work-group id (both 1-based), a name for
+  other exceptions, and a device-side backtrace.
+
+```julia
+@opencl debug_level=2 (a -> (a[2] = 1f0; return))(a)
+try
+    cl.finish(cl.queue())
+catch exc
+    @show exc.dev exc.name exc.reason
+    @show exc.work_item exc.work_group exc.backtrace
+end
+```
+
+Backtrace entries are `(function, file, line)` tuples. Fields unavailable at the selected
+level contain empty strings, empty vectors, or zero coordinates. Names, reasons, function
+names, and file paths are limited to 63, 191, 127, and 127 bytes respectively; backtraces
+contain at most 16 frames. Level 2 adds more code to throwing paths and is intended for
+debugging.
+
+## Synchronization and memory
+
+Each device in an OpenCL context has a host-visible exception mailbox, allocated on first
+launch. Queues targeting that device share the mailbox, so checking one queue may wait for
+and report a failure from another queue on the same device. `exc.dev` identifies that device.
+Only one faulting work-item records detailed diagnostics until the host consumes the report.
+Its launch identifier and coordinates distinguish it from other work-items and later kernels.
+
+Mailbox allocation tries USM host memory, fine-grained SVM, coarse-grained SVM, then a
+host-accessible buffer with `cl_ext_buffer_device_address`. The memory must be supported by
+the context's devices. Coarse-grained SVM and buffers are mapped only after all queues using
+the mailbox have completed, and unmapped before another launch can access them.
+
+If no supported memory mechanism is available, OpenCL.jl warns on first use and runs without
+host-side exception reporting. Finalizer-driven synchronization leaves reports pending for
+the next ordinary synchronization. Mailboxes and their contexts are currently retained for
+the lifetime of the process.

--- a/lib/cl/cmdqueue.jl
+++ b/lib/cl/cmdqueue.jl
@@ -60,8 +60,11 @@ function flush(q::CmdQueue)
     return q
 end
 
-function finish(q::CmdQueue)
-    clFinish(q)
+# `check_exceptions` surfaces device-side exceptions thrown by kernels that ran on the
+# queue; disable it where throwing is not an option (e.g. finalizers), in which case the
+# exception remains pending until the next check.
+function finish(q::CmdQueue; check_exceptions::Bool=true)
+    OpenCL.check_exceptions(q; rethrow=check_exceptions)
     return q
 end
 

--- a/lib/cl/memory/buffer.jl
+++ b/lib/cl/memory/buffer.jl
@@ -130,7 +130,8 @@ enqueue_copy(dst::Buffer, src::Buffer, N; kwargs...) =
 
 # map a buffer into the host address space, returning a pointer and an event
 function enqueue_map(buf::Buffer, offset::Integer, nbytes::Int, flags=:rw;
-                     blocking::Bool=false, wait_for::Vector{Event}=Event[])
+                     queue::CmdQueue=queue(), blocking::Bool=false,
+                     wait_for::Vector{Event}=Event[])
     flags = if flags == :rw
         CL_MAP_READ | CL_MAP_WRITE
     elseif flags == :r
@@ -146,7 +147,7 @@ function enqueue_map(buf::Buffer, offset::Integer, nbytes::Int, flags=:rw;
     evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
     GC.@preserve wait_for begin
         status  = Ref{Cint}()
-        ptr = clEnqueueMapBuffer(queue(), buf, blocking, flags, offset, nbytes,
+        ptr = clEnqueueMapBuffer(queue, buf, blocking, flags, offset, nbytes,
                                  n_evts, evt_ids, ret_evt, status)
         if status[] != CL_SUCCESS
             throw(CLError(status[]))
@@ -159,12 +160,13 @@ enqueue_map(buf::Buffer, nbytes::Int, flags=:rw; kwargs...) =
     enqueue_map(buf, 0, nbytes, flags; kwargs...)
 
 # unmap a buffer, return an event
-function enqueue_unmap(buf::Buffer, ptr::Ptr; wait_for::Vector{Event}=Event[])
+function enqueue_unmap(buf::Buffer, ptr::Ptr; queue::CmdQueue=queue(),
+                       wait_for::Vector{Event}=Event[])
     n_evts  = length(wait_for)
     evt_ids = isempty(wait_for) ? C_NULL : [pointer(evt) for evt in wait_for]
     GC.@preserve wait_for begin
         ret_evt = Ref{cl_event}()
-        clEnqueueUnmapMemObject(queue(), buf, ptr, n_evts, evt_ids, ret_evt)
+        clEnqueueUnmapMemObject(queue, buf, ptr, n_evts, evt_ids, ret_evt)
         return Event(ret_evt[])
     end
 end

--- a/src/OpenCL.jl
+++ b/src/OpenCL.jl
@@ -36,6 +36,7 @@ include("array.jl")
 # compiler implementation
 include("compiler/capabilities.jl")
 include("compiler/compilation.jl")
+include("compiler/exceptions.jl")
 include("compiler/execution.jl")
 include("compiler/reflection.jl")
 include("compiler/precompile.jl")

--- a/src/array.jl
+++ b/src/array.jl
@@ -430,6 +430,9 @@ for (srcty, dstty) in [(:Array, :CLArray), (:CLArray, :Array), (:CLArray, :CLArr
                         end
                     end
                 end
+                # a blocking copy completes the kernels queued before it, so surface any
+                # exception they threw rather than returning their garbage
+                blocking && cl.finish(cl.queue())
             end
         end
         Base.unsafe_copyto!(dst::$dstty, src::$srcty, N; kwargs...) =

--- a/src/compiler/compilation.jl
+++ b/src/compiler/compilation.jl
@@ -172,6 +172,7 @@ end
 const SPIRV_VERSION = v"1.4"
 
 @noinline function _compiler_config(dev, backend; kernel=true, name=nothing, always_inline=false,
+                                     debug_level=Base.JLOptions().debug_level,
                                      sub_group_size::Union{Nothing,Int}=_sub_group_size(dev),
                                      extensions::Union{Nothing,AbstractVector{<:AbstractString}}=nothing,
                                      kwargs...)
@@ -212,7 +213,7 @@ const SPIRV_VERSION = v"1.4"
                                    validate=true, extensions=spirv_ext, backend=llvm_to_spirv_backend,
                                    kwargs...)
     params = OpenCLCompilerParams(; sub_group_size, features, program_backend=backend)
-    CompilerConfig(target, params; kernel, name, always_inline)
+    CompilerConfig(target, params; kernel, name, always_inline, debug_level)
 end
 
 # run inference + LLVM codegen + SPIR-V emission. returns `(obj, entry, device_rng)`,

--- a/src/compiler/exceptions.jl
+++ b/src/compiler/exceptions.jl
@@ -1,0 +1,252 @@
+# support for device-side exceptions
+
+## exception type
+
+"""
+    KernelException
+
+An exception thrown during kernel execution on `dev`, detected when synchronizing
+(`cl.finish`, a blocking copy, `Array(x)`, ...).
+
+How much is known about the exception depends on the debug level the kernel was compiled
+with (the session's `-g` level, or `@opencl debug_level=`):
+
+- `0`: only that an exception was thrown;
+- `1`: additionally its type `name` and `reason`, for exceptions thrown by Julia's runtime
+  (bounds errors, domain errors, ...);
+- `2`: additionally the position of the faulting work-item (`work_item` is its local id,
+  `work_group` the id of its work-group), the name of any other exception, and a device-side
+  `backtrace` as `(function, file, line)` tuples.
+
+`dev` identifies the device whose mailbox reported the exception.
+Fields that were not recorded are empty strings, empty vectors, or all-zero tuples.
+"""
+struct KernelException <: Exception
+    dev::cl.Device
+    name::String
+    reason::String
+    work_item::NTuple{3, Int}
+    work_group::NTuple{3, Int}
+    backtrace::Vector{Tuple{String, String, Int}}   # (function, file, line) per frame
+end
+
+# Positions are 1-based, so zero coordinates indicate that level 2 details were not recorded.
+function Base.showerror(io::IO, err::KernelException)
+    name = isempty(err.name) ? "exception" : err.name
+    article = first(uppercase(name)) in ('A', 'E', 'I', 'O', 'U') ? "An" : "A"
+    print(io, "KernelException: $article $name was thrown")
+    if err.work_item != (0, 0, 0)
+        work_item = join(err.work_item, '×')
+        work_group = join(err.work_group, '×')
+        print(io, " by work-item $work_item in work-group $work_group")
+    end
+    print(io, " on device ", err.dev.name)
+    isempty(err.reason) || print(io, ": ", err.reason)
+    if err.work_item == (0, 0, 0)
+        print(io, "\nFor more details, run Julia with `-g2`, or launch the kernel with `@opencl debug_level=2`")
+    else
+        print(io, "\nStacktrace:")
+        for (i, (func, file, line)) in enumerate(err.backtrace)
+            print(io, "\n [", i, "] ", func)
+            isempty(file) || print(io, " at ", file, ":", line)
+        end
+    end
+end
+
+# decode a null-terminated mailbox text buffer into a `String`
+function exception_string(bytes::NTuple{N, UInt8}) where {N}
+    len = something(findfirst(iszero, bytes), N + 1) - 1
+    return String(UInt8[bytes[i] for i in 1:len])
+end
+
+
+## exception mailbox
+
+# One mailbox per (context, device), shared by its queues. Track submissions so host
+# access, including mapping coarse-grained memory, waits for every possible writer.
+mutable struct ExceptionMailbox
+    # the host-accessible memory backing the mailbox, or `nothing` when the context's
+    # devices don't support any (in which case kernels get a zero address)
+    const mem::Union{Nothing, cl.AbstractMemory}
+    const address::UInt64
+    # whether host access requires mapping the memory (coarse-grained SVM, buffers)
+    const mapped::Bool
+    # serialize launches and checks for this mailbox
+    const lock::ReentrantLock
+    # queues that have launched kernels since the mailbox was last checked on them
+    const pending::Set{cl.CmdQueue}
+    # assigned under the lock; distinguishes work-items from different launches
+    launch_id::UInt64
+end
+
+# Device-scoped atomics cannot protect a mailbox shared by different devices. These strong
+# references retain contexts and backing allocations for the lifetime of the process.
+const exception_mailboxes = Dict{Tuple{cl.Context, cl.Device}, ExceptionMailbox}()
+const exception_mailboxes_lock = ReentrantLock()
+
+# the kinds of memory a mailbox can live in, in order of preference: memory the host can
+# access directly comes first, memory that needs mapping around every host access last.
+const exception_mailbox_backends = (:usm, :svm_fine, :svm_coarse, :buffer)
+
+# allocate a mailbox in memory all devices in the context can reach by pointer, trying the
+# given backends in order.
+function allocate_exception_mailbox(ctx::cl.Context, queue::cl.CmdQueue=cl.queue();
+                                    backends=exception_mailbox_backends)
+    devs = ctx.devices
+    sz = sizeof(ExceptionInfo_st)
+    mem, mapped = cl.context!(ctx) do
+        for backend in backends
+            if backend === :usm
+                if all(dev -> cl.usm_supported(dev) && cl.usm_capabilities(dev).host.access, devs)
+                    return cl.host_alloc(sz), false
+                end
+            elseif backend === :svm_fine
+                if all(dev -> cl.svm_capabilities(dev).fine_grain_buffer, devs)
+                    return cl.svm_alloc(sz; fine_grained=true), false
+                end
+            elseif backend === :svm_coarse
+                if all(dev -> cl.svm_capabilities(dev).coarse_grain_buffer, devs)
+                    return cl.svm_alloc(sz), true
+                end
+            elseif backend === :buffer
+                if all(cl.bda_supported, devs)
+                    return cl.Buffer(sz; host_accessible=true, device_private_address=true), true
+                end
+            else
+                throw(ArgumentError("Unknown exception mailbox backend $backend"))
+            end
+        end
+        return nothing, false
+    end
+
+    if mem === nothing
+        @warn """Device-side exceptions cannot be reported on $(join(map(dev -> dev.name, devs), ", ")): \
+                 the device does not support any host-accessible memory to put the exception mailbox in.
+                 Kernels that throw will complete silently."""
+        return ExceptionMailbox(nothing, UInt64(0), false, ReentrantLock(),
+                                Set{cl.CmdQueue}(), UInt64(0))
+    end
+
+    mailbox = ExceptionMailbox(mem, UInt64(UInt(pointer(mem))), mapped, ReentrantLock(),
+                               Set{cl.CmdQueue}(), UInt64(0))
+    with_exception_mailbox(mailbox, queue) do ptr
+        unsafe_store!(ptr, ExceptionInfo_st())
+    end
+    return mailbox
+end
+
+# run `f` with a host pointer to the mailbox, mapping its memory through `queue` as needed
+function with_exception_mailbox(f, mailbox::ExceptionMailbox, queue::cl.CmdQueue)
+    sz = sizeof(ExceptionInfo_st)
+    mem = mailbox.mem
+    if mem isa cl.Buffer
+        ptr, _ = cl.enqueue_map(mem, sz, :rw; queue, blocking=true)
+        try
+            return f(convert(Ptr{ExceptionInfo_st}, ptr))
+        finally
+            cl.enqueue_unmap(mem, ptr; queue)
+            # A later launch may use another queue, so complete the unmap before releasing
+            # the mailbox lock.
+            cl.clFinish(queue)
+        end
+    end
+    ptr = convert(Ptr{ExceptionInfo_st}, mem)
+    mailbox.mapped || return f(ptr)
+    clptr = convert(CLPtr{Cvoid}, mem)
+    cl.enqueue_svm_map(clptr, sz, :rw; queue, blocking=true)
+    try
+        return f(ptr)
+    finally
+        cl.enqueue_svm_unmap(clptr; queue)
+        # A later launch may use another queue, so complete the unmap before releasing
+        # the mailbox lock.
+        cl.clFinish(queue)
+    end
+end
+
+# Launch while holding the mailbox lock, so a concurrent synchronization cannot finish the
+# queue between enqueue and recording it as pending (or map the mailbox during submission).
+# Keep this in an ordinary function: the generated `AbstractKernel` call cannot contain a
+# closure or `do` block on Julia 1.13.
+function launch_with_exception_mailbox(kernel::cl.Kernel, args...;
+                                       indirect_memory::Vector{cl.AbstractMemory},
+                                       rng_state::Bool, kwargs...)
+    ctx, dev, queue = cl.context(), cl.device(), cl.queue()
+    mailbox = Base.@lock exception_mailboxes_lock begin
+        get!(exception_mailboxes, (ctx, dev)) do
+            allocate_exception_mailbox(ctx, queue)
+        end
+    end
+    Base.@lock mailbox.lock begin
+        mailbox.mem === nothing || push!(indirect_memory, mailbox.mem)
+        mailbox.launch_id += UInt64(1)
+        state = KernelState(rng_state ? Base.rand(UInt32) : UInt32(0), mailbox.address,
+                            mailbox.launch_id)
+        result = cl.call(kernel, state, args...; indirect_memory, rng_state, kwargs...)
+        if mailbox.mem !== nothing
+            push!(mailbox.pending, queue)
+        end
+        return result
+    end
+end
+
+"""
+    check_exceptions(queue::cl.CmdQueue)
+
+Synchronize `queue` and every other queue recorded against its device's mailbox, then check
+whether a kernel threw an exception and, if so, rethrow it host-side as a
+[`KernelException`](@ref).
+
+The exception mailbox is shared by queues targeting the same device in a context, so this
+may wait for and surface an exception from another queue on that device.
+"""
+function check_exceptions(queue::cl.CmdQueue; rethrow::Bool=true)
+    # Finalizers cannot yield while waiting for a contended Julia lock. Finish the queue
+    # without touching mailbox bookkeeping; an ordinary check will finish it again and
+    # consume the report. This also keeps finalizers independent of task-local state.
+    if !rethrow
+        cl.clFinish(queue)
+        return
+    end
+    mailbox = Base.@lock exception_mailboxes_lock begin
+        get(exception_mailboxes, (queue.context, queue.device), nothing)
+    end
+    if mailbox === nothing
+        cl.clFinish(queue)
+        return
+    end
+    Base.@lock mailbox.lock begin
+        # Keep this raw: `cl.finish` delegates here in order to hold the mailbox lock across
+        # both synchronization and inspection.
+        cl.clFinish(queue)
+        isempty(mailbox.pending) && return
+
+        # The mailbox cannot be mapped or read while another queue may still access it.
+        # Finish all queues that launched with its address; the launch-side lock prevents a
+        # new enqueue from appearing between this loop and the reset below.
+        for pending in mailbox.pending
+            pending == queue || cl.clFinish(pending)
+        end
+
+        exc = with_exception_mailbox(mailbox, queue) do ptr
+            status_ptr = convert(Ptr{Int32}, ptr)
+            unsafe_load(status_ptr) == 0 && return nothing
+            info = unsafe_load(ptr)
+            nframes = min(Int(info.num_frames), EXCEPTION_MAX_FRAMES)
+            backtrace = Tuple{String, String, Int}[
+                (exception_string(info.frames[i].func),
+                 exception_string(info.frames[i].file),
+                 Int(info.frames[i].line)) for i in 1:nframes]
+            # clear the flag, lock and payload so the mailbox is reusable (and other queues
+            # checking it don't re-report the exception)
+            unsafe_store!(ptr, ExceptionInfo_st())
+            KernelException(queue.device, exception_string(info.name),
+                            exception_string(info.reason),
+                            Int.(info.work_item[1:3]), Int.(info.work_group[1:3]),
+                            backtrace)
+        end
+        empty!(mailbox.pending)
+        exc === nothing || throw(exc)
+    end
+    return
+end

--- a/src/compiler/execution.jl
+++ b/src/compiler/execution.jl
@@ -4,9 +4,30 @@ export @opencl, clfunction
 ## high-level @opencl interface
 
 const MACRO_KWARGS = [:launch]
-const COMPILER_KWARGS = [:kernel, :name, :always_inline, :extensions, :backend, :validate, :sub_group_size]
+const COMPILER_KWARGS = [:kernel, :name, :always_inline, :debug_level, :extensions, :backend, :validate, :sub_group_size]
 const LAUNCH_KWARGS = [:global_size, :local_size, :queue]
 
+"""
+    @opencl [kwargs...] func(args...)
+
+High-level interface for executing code on an OpenCL device.
+
+The `@opencl` macro should prefix a call, with `func` a callable function or object that
+should return nothing. It will be compiled to an OpenCL kernel upon first use, and to a
+certain extent arguments will be converted and managed automatically using
+`kernel_convert`. Finally, the kernel is launched on the current queue.
+
+There are a few keyword arguments that influence the behavior of `@opencl`:
+
+- `launch`: whether to launch this kernel, defaults to `true`. If `false`, the returned
+  kernel object should be launched by calling it and passing arguments again.
+- `name`: the name of the kernel in the generated code. Defaults to an automatically-
+  generated name.
+- `debug_level`: how much a device-side exception reports, from `0` (only that one was
+  thrown) to `2` (its type, reason, position and backtrace). Defaults to the session's
+  `-g` level; see [`KernelException`](@ref).
+- `global_size`, `local_size`: the launch configuration, as in OpenCL.
+"""
 macro opencl(ex...)
     call = ex[end]
     kwargs = map(ex[1:end-1]) do kwarg
@@ -166,9 +187,6 @@ pass_arg(@nospecialize dt) = !(isghosttype(dt) || Core.Compiler.isconstType(dt))
         end
     end
 
-    pushfirst!(call_t, KernelState)
-    pushfirst!(call_args, :(KernelState(kernel.rng_state ? Base.rand(UInt32) : UInt32(0))))
-
     # convert arguments before locking (conversion is pure, and collects the managed
     # allocations to lock), then perform the launch transaction: with all participating
     # allocations locked in stable order, migrate their queue ownership and enqueue the
@@ -186,8 +204,9 @@ pass_arg(@nospecialize dt) = !(isghosttype(dt) || Core.Compiler.isconstType(dt))
             locked = lock_managed(managed)
             try
                 foreach(take_ownership!, locked)
-                cl.call(kernel.fun, $(converted...);
-                        indirect_memory, kernel.rng_state, call_kwargs...)
+                launch_with_exception_mailbox(kernel.fun, $(converted...);
+                                              indirect_memory, rng_state=kernel.rng_state,
+                                              call_kwargs...)
             finally
                 unlock_managed(locked)
             end

--- a/src/device/quirks.jl
+++ b/src/device/quirks.jl
@@ -1,46 +1,73 @@
-macro print_and_throw(args...)
-    quote
-        @println "ERROR: " $(args...) "."
-        throw(nothing)
-    end
-end
-
 # math.jl
 @device_override @noinline Base.Math.throw_complex_domainerror(f::Symbol, x) =
-    @print_and_throw "This operation requires a complex input to return a complex result"
+    @gputhrow "DomainError" "This operation requires a complex input to return a complex result"
 @device_override @noinline Base.Math.throw_exp_domainerror(x) =
-    @print_and_throw "Exponentiation yielding a complex result requires a complex argument"
+    @gputhrow "DomainError" "Exponentiation yielding a complex result requires a complex argument"
 @static if isdefined(Base.Math, :throw_finite_domainerror)
     @device_override @noinline Base.Math.throw_finite_domainerror(f::Symbol, x) =
-        @print_and_throw f "(x) is only defined for finite x."
+        @gputhrow "DomainError" "function is only defined for finite x."
+end
+@device_override function Base.Math.exponent(x::T) where T<:Base.IEEEFloat
+    xs = reinterpret(Unsigned, x) & ~Base.sign_mask(T)
+    xs >= Base.exponent_mask(T) && @gputhrow "DomainError" "Cannot be NaN or Inf."
+    k = Int(xs >> Base.significand_bits(T))
+    if k == 0 # x is subnormal
+        xs == 0 && @gputhrow "DomainError" "Cannot be ±0.0."
+        m = leading_zeros(xs) - Base.exponent_bits(T)
+        k = 1 - m
+    end
+    return k - Base.exponent_bias(T)
 end
 
 # intfuncs.jl
 @device_override @noinline Base.throw_domerr_powbysq(::Any, p) =
-    @print_and_throw "Cannot raise an integer to a negative power"
+    @gputhrow "DomainError" "Cannot raise an integer to a negative power"
 @device_override @noinline Base.throw_domerr_powbysq(::Integer, p) =
-    @print_and_throw "Cannot raise an integer to a negative power"
+    @gputhrow "DomainError" "Cannot raise an integer to a negative power"
 @device_override @noinline Base.throw_domerr_powbysq(::AbstractMatrix, p) =
-    @print_and_throw "Cannot raise an integer to a negative power"
+    @gputhrow "DomainError" "Cannot raise an integer to a negative power"
 
 # checked.jl
 @device_override @noinline Base.Checked.throw_overflowerr_binaryop(op, x, y) =
-    @print_and_throw "Binary operation overflowed"
+    @gputhrow "OverflowError" "Binary operation overflowed"
 @device_override @noinline Base.Checked.throw_overflowerr_negation(op, x, y) =
-    @print_and_throw "Negation overflowed"
+    @gputhrow "OverflowError" "Negation overflowed"
 
 # boot.jl
 @device_override @noinline Core.throw_inexacterror(f::Symbol, ::Type{T}, val) where {T} =
-    @print_and_throw "Inexact conversion"
+    @gputhrow "InexactError" "Inexact conversion"
+
+# bool.jl / float.jl
+# `Bool(::Real)` and `Bool(::Float16)` don't go through `throw_inexacterror` but construct
+# the `InexactError` themselves, through its vararg `@nospecialize` constructor. On the
+# device that means boxing the arguments on the throwing branch (an allocation the
+# optimizer can't remove), so route them through `@gputhrow` instead.
+for T in (Real, Float16)
+    @eval @device_override function Base.Bool(x::$T)
+        x == 0 && return false
+        x == 1 && return true
+        @gputhrow "InexactError" "Inexact conversion"
+    end
+end
 
 # abstractarray.jl
 @device_override @noinline Base.throw_boundserror(A, I) =
-    @print_and_throw "Out-of-bounds array access"
+    @gputhrow "BoundsError" "Out-of-bounds array access"
+
+# essentials.jl
+# Julia 1.14 routes indexed bounds errors through `_throw_boundserror_indices`
+# rather than `throw_boundserror`, bypassing the override above.
+@static if isdefined(Base, :_throw_boundserror_indices)
+    @device_override @noinline Base._throw_boundserror_indices(A) =
+        @gputhrow "BoundsError" "Out-of-bounds array access"
+    @device_override @noinline Base._throw_boundserror_indices(A, i1, I...) =
+        @gputhrow "BoundsError" "Out-of-bounds array access"
+end
 
 # trig.jl
 @static if isdefined(Base.Math, :sincos_domain_error)
     @device_override @noinline Base.Math.sincos_domain_error(x) =
-        @print_and_throw "sincos(x) is only defined for finite x."
+        @gputhrow "DomainError" "sincos(x) is only defined for finite x."
 end
 
 # diagonal.jl
@@ -51,7 +78,7 @@ import LinearAlgebra
     if i == j
         @inbounds D.diag[i] = v
     elseif !iszero(v)
-        @print_and_throw "cannot set off-diagonal entry to a nonzero value"
+        @gputhrow "ArgumentError" "cannot set off-diagonal entry to a nonzero value"
     end
     return v
 end
@@ -60,7 +87,7 @@ end
 # XXX: remove when we have malloc
 @device_override @inline function Base.getindex(x::Number, I::Integer...)
     @boundscheck all(isone, I) ||
-        @print_and_throw "Out-of-bounds access of scalar value"
+        @gputhrow "BoundsError" "Out-of-bounds access of scalar value"
     x
 end
 

--- a/src/device/runtime.jl
+++ b/src/device/runtime.jl
@@ -1,19 +1,240 @@
-signal_exception() = return
+## exception mailbox
 
-malloc(sz) = C_NULL
+# Kernels report into host-visible memory passed through KernelState. The host reads and
+# resets the mailbox after all queues that used it have completed.
+
+# Text capacities include the null terminator. Backtraces are recorded at debug level 2.
+const EXCEPTION_NAME_LEN   = 64
+const EXCEPTION_REASON_LEN = 192
+const EXCEPTION_FUNC_LEN   = 128
+const EXCEPTION_FILE_LEN   = 128
+const EXCEPTION_MAX_FRAMES = 16
+
+struct ExceptionFrame_st
+    func::NTuple{EXCEPTION_FUNC_LEN, UInt8}
+    file::NTuple{EXCEPTION_FILE_LEN, UInt8}
+    line::Int32
+
+    ExceptionFrame_st() = new(ntuple(_ -> 0x00, EXCEPTION_FUNC_LEN),
+                              ntuple(_ -> 0x00, EXCEPTION_FILE_LEN), 0)
+end
+
+struct ExceptionInfo_st
+    # whether an exception has been encountered (0 -> 1)
+    status::Int32
+    # claim state: 0 = unclaimed, 1 = claimed, 2 = owner published for re-entry
+    output_lock::Int32
+    # distinguish identical work-item coordinates in different kernel launches
+    launch_id::UInt64
+    # Keep positions at the builtins' 64-bit width and pad to four components. Narrowing
+    # or merging adjacent three-component accesses can produce illegal six-wide SPIR-V
+    # vectors. At level 2 these coordinates also identify the owner within a launch.
+    work_item::NTuple{4, UInt64}
+    work_group::NTuple{4, UInt64}
+    # the exception type name and reason, as null-terminated text the host reads back
+    name::NTuple{EXCEPTION_NAME_LEN, UInt8}
+    reason::NTuple{EXCEPTION_REASON_LEN, UInt8}
+    # the device-side stack trace, captured at debug level >= 2
+    num_frames::Int32
+    frames::NTuple{EXCEPTION_MAX_FRAMES, ExceptionFrame_st}
+
+    ExceptionInfo_st() = new(0, 0, 0, (0, 0, 0, 0), (0, 0, 0, 0),
+                             ntuple(_ -> 0x00, EXCEPTION_NAME_LEN),
+                             ntuple(_ -> 0x00, EXCEPTION_REASON_LEN),
+                             0, ntuple(_ -> ExceptionFrame_st(), EXCEPTION_MAX_FRAMES))
+end
+
+# Access fields through typed device pointers derived from the host struct layout.
+const ExceptionInfo = LLVMPtr{UInt8, AS.CrossWorkgroup}
+
+const EXCEPTION_INFO_OFFSETS = NamedTuple{fieldnames(ExceptionInfo_st)}(
+    Tuple(Int(fieldoffset(ExceptionInfo_st, i)) for i in 1:fieldcount(ExceptionInfo_st)))
+const EXCEPTION_FRAME_OFFSETS = NamedTuple{fieldnames(ExceptionFrame_st)}(
+    Tuple(Int(fieldoffset(ExceptionFrame_st, i)) for i in 1:fieldcount(ExceptionFrame_st)))
+const EXCEPTION_FRAME_SIZE = sizeof(ExceptionFrame_st)
+
+@inline info_field(info::ExceptionInfo, ::Val{field}) where {field} =
+    reinterpret(LLVMPtr{fieldtype(ExceptionInfo_st, field), AS.CrossWorkgroup},
+                info + getfield(EXCEPTION_INFO_OFFSETS, field))
+@inline frame_field(frame::ExceptionInfo, ::Val{field}) where {field} =
+    reinterpret(LLVMPtr{fieldtype(ExceptionFrame_st, field), AS.CrossWorkgroup},
+                frame + getfield(EXCEPTION_FRAME_OFFSETS, field))
+
+# a byte pointer to the `idx`-th frame (1-based) in the mailbox's frame array
+@inline frame_pointer(info::ExceptionInfo, idx) =
+    info + EXCEPTION_INFO_OFFSETS.frames + (idx - 1) * EXCEPTION_FRAME_SIZE
+
+# the mailbox address as carried by the kernel state; null when the device has no
+# host-accessible memory to put a mailbox in (see `allocate_exception_mailbox`).
+@inline exception_info() = reinterpret(ExceptionInfo, kernel_state().exception_info)
+@inline has_exception_info(info::ExceptionInfo) = info != reinterpret(ExceptionInfo, 0)
+
+# Claims must cover all work-groups and queues on the device. SPIRVIntrinsics' public
+# atomic helpers currently use work-group scope.
+@inline function atomic_claim_device!(p::LLVMPtr{Int32, AS.CrossWorkgroup})
+    @typed_ccall("_Z29__spirv_AtomicCompareExchangePU3AS1Vijjjii", llvmcall, Int32,
+                 (LLVMPtr{Int32, AS.CrossWorkgroup}, UInt32, UInt32, UInt32, Int32, Int32),
+                 p, UInt32(Scope.Device),
+                 UInt32(MemorySemantics.CrossWorkgroupMemory | MemorySemantics.AcquireRelease),
+                 UInt32(MemorySemantics.CrossWorkgroupMemory | MemorySemantics.Acquire),
+                 Int32(1), Int32(0))
+end
+
+@inline function atomic_store_device!(p::LLVMPtr{Int32, AS.CrossWorkgroup}, val::Int32)
+    @typed_ccall("_Z19__spirv_AtomicStorePU3AS1Vijji", llvmcall, Cvoid,
+                 (LLVMPtr{Int32, AS.CrossWorkgroup}, UInt32, UInt32, Int32),
+                 p, UInt32(Scope.Device),
+                 UInt32(MemorySemantics.CrossWorkgroupMemory | MemorySemantics.Release), val)
+end
+
+# Store literal text as words to avoid a device-side copy loop. Name and reason buffers
+# are 8-byte aligned and sized; zero-padding supplies the terminator. Keep this out of line
+# because GPUCompiler inlines throwing functions into every call site.
+@generated function store_string!(dest::LLVMPtr{NTuple{N, UInt8}, AS.CrossWorkgroup},
+                                  ::Val{str}) where {N, str}
+    bytes = collect(codeunits(String(str)))
+    n = min(length(bytes), N - 1)
+    padded = bytes[1:n]
+    push!(padded, 0x00)                              # null terminator
+    while length(padded) % sizeof(UInt64) != 0       # zero-pad to a word boundary
+        push!(padded, 0x00)
+    end
+    exprs = Expr[Expr(:meta, :noinline),
+                 :(base = reinterpret(LLVMPtr{UInt64, AS.CrossWorkgroup}, dest))]
+    for w in 0:(length(padded) ÷ sizeof(UInt64) - 1)
+        word = UInt64(0)
+        for b in 0:(sizeof(UInt64) - 1)              # little-endian pack
+            word |= UInt64(padded[w * sizeof(UInt64) + b + 1]) << (8 * b)
+        end
+        push!(exprs, :(unsafe_store!(base + $(w * sizeof(UInt64)), $word)))
+    end
+    push!(exprs, :(return nothing))
+    return Expr(:block, exprs...)
+end
+
+# Runtime strings (GPUCompiler's names and frames) need a bounded byte copy.
+@noinline function store_cstring!(dest::LLVMPtr{NTuple{N, UInt8}, AS.CrossWorkgroup},
+                                  src::LLVMPtr{Cchar, AS.CrossWorkgroup}) where {N}
+    base = reinterpret(LLVMPtr{UInt8, AS.CrossWorkgroup}, dest)
+    i = 0
+    while i < N - 1
+        c = unsafe_load(src + i) % UInt8
+        c == 0x00 && break
+        unsafe_store!(base + i, c)
+        i += 1
+    end
+    unsafe_store!(base + i, 0x00)
+    return
+end
+
+# Fold away all reporting at level 0. Only the owner may write details; level 2 allows
+# that work-item to re-enter for the separate name and backtrace callbacks.
+@inline lock_output!(info) = kernel_debug_level() < 1 ? false : claim_output!(info)
+
+# Keep the claim out of line to limit code growth in kernels with many checked accesses.
+@noinline function claim_output!(info)
+    has_exception_info(info) || return false
+    lock_ptr = info_field(info, Val(:output_lock))
+    claimed = atomic_claim_device!(lock_ptr)
+    # At level 1 all details are recorded in one call; only level 2 needs re-entry.
+    kernel_debug_level() < 2 && return claimed == 0
+
+    item = (get_local_id(1) % UInt64, get_local_id(2) % UInt64, get_local_id(3) % UInt64,
+            UInt64(0))
+    group = (get_group_id(1) % UInt64, get_group_id(2) % UInt64, get_group_id(3) % UInt64,
+             UInt64(0))
+    launch_id = kernel_state().launch_id
+    if claimed == 0
+        unsafe_store!(info_field(info, Val(:launch_id)), launch_id)
+        unsafe_store!(info_field(info, Val(:work_item)), item)
+        unsafe_store!(info_field(info, Val(:work_group)), group)
+        # Publish the owner before another work-item reads it. A losing claimant must
+        # never spin: the owner might be an inactive lane of the same subgroup.
+        atomic_store_device!(lock_ptr, Int32(2))
+        return true
+    end
+    claimed == 2 || return false
+    # The acquire above pairs with publication. Coordinates alone are insufficient:
+    # another kernel can use the same work-item and work-group ids.
+    return unsafe_load(info_field(info, Val(:launch_id))) == launch_id &&
+           unsafe_load(info_field(info, Val(:work_item))) == item &&
+           unsafe_load(info_field(info, Val(:work_group))) == group
+end
+
+# One helper per name/reason pair keeps each throw site to a single cold call.
+@noinline function record_exception!(info, ::Val{name}, ::Val{reason}) where {name, reason}
+    if lock_output!(info)
+        store_string!(info_field(info, Val(:name)),   Val(name))
+        store_string!(info_field(info, Val(:reason)), Val(reason))
+    end
+    return
+end
+
+# Record literal diagnostics before entering GPUCompiler's exception lowering.
+macro gputhrow(name::String, reason::String)
+    name_q = QuoteNode(Symbol(name))
+    reason_q = QuoteNode(Symbol(reason))
+    return quote
+        # the gate folds to a constant, so `-g0` kernels don't even carry the call
+        if kernel_debug_level() >= 1
+            record_exception!(exception_info(), Val($name_q), Val($reason_q))
+        end
+        throw(nothing)
+    end
+end
+
+function signal_exception()
+    info = exception_info()
+    # All faulting work-items signal, including level 0 kernels that do not claim a record.
+    # Kernel completion makes both the status and any recorded details visible to the host.
+    if has_exception_info(info)
+        atomic_store_device!(info_field(info, Val(:status)), Int32(1))
+    end
+    return
+end
+
+# Preserve a quirk's more precise literal name. Copy GPUCompiler's runtime strings only
+# at level 2, keeping data-dependent copy loops out of ordinary level 1 throw paths.
+function report_exception(ex)
+    if kernel_debug_level() >= 2
+        info = exception_info()
+        name = info_field(info, Val(:name))
+        if lock_output!(info) &&
+           unsafe_load(reinterpret(LLVMPtr{UInt8, AS.CrossWorkgroup}, name)) == 0x00
+            store_cstring!(name, ex)
+        end
+    end
+    return
+end
+report_exception_name(ex) = report_exception(ex)
+
+# GPUCompiler reports each stack frame (recovered from debug info) at debug level >= 2.
+function report_exception_frame(idx, func, file, line)
+    info = exception_info()
+    if lock_output!(info) && 1 <= idx <= EXCEPTION_MAX_FRAMES
+        frame = frame_pointer(info, idx)
+        store_cstring!(frame_field(frame, Val(:func)), func)
+        store_cstring!(frame_field(frame, Val(:file)), file)
+        unsafe_store!(frame_field(frame, Val(:line)), Int32(line))
+        unsafe_store!(info_field(info, Val(:num_frames)), Int32(idx))
+    end
+    return
+end
 
 report_oom(sz) = return
 
-report_exception(ex) = return
-
-report_exception_name(ex) = return
-
-report_exception_frame(idx, func, file, line) = return
+malloc(sz) = C_NULL
 
 ## kernel state
 
 struct KernelState
     random_seed::UInt32
+
+    # address of the device-side exception mailbox (`ExceptionInfo_st`); zero when the
+    # device has no host-accessible memory to put it in. carried as an integer rather than
+    # a pointer: SPIR-V validation rejects pointer-typed fields in by-value kernel arguments.
+    exception_info::UInt64
+    launch_id::UInt64
 end
 
 @inline @generated kernel_state() = GPUCompiler.kernel_state_value(KernelState)

--- a/src/memory.jl
+++ b/src/memory.jl
@@ -55,9 +55,9 @@ function with_managed_locks(f::F, managed::AbstractVector{<:Managed}) where {F}
 end
 
 # wait for the current owner of memory to finish processing
-function synchronize(managed::Managed)
+function synchronize(managed::Managed; check_exceptions::Bool=true)
     return Base.@lock managed.lock begin
-        cl.finish(managed.queue)
+        cl.finish(managed.queue; check_exceptions)
         managed.dirty = false
         nothing
     end
@@ -225,7 +225,8 @@ function free(managed::Managed)
         # before freeing svm_pointer". USM has `clMemBlockingFreeINTEL`, but by doing the
         # synchronization ourselves we provide more opportunity for concurrent execution.
         if managed.queue.valid
-            synchronize(managed)
+            # this may run from a finalizer, where a device-side exception cannot be thrown
+            synchronize(managed; check_exceptions=false)
         end
 
         if mem isa cl.SharedVirtualMemory
@@ -233,7 +234,7 @@ function free(managed::Managed)
                 # Finalizers must not query or mutate task-local state, so use the queue owned by
                 # the allocation. Finish the unmap before releasing the SVM allocation.
                 cl.enqueue_svm_unmap(pointer(mem); queue=managed.queue)
-                cl.finish(managed.queue)
+                cl.finish(managed.queue; check_exceptions=false)
             end
             cl.svm_free(mem)
         elseif mem isa cl.UnifiedMemory

--- a/test/exceptions.jl
+++ b/test/exceptions.jl
@@ -1,0 +1,347 @@
+using KernelAbstractions
+
+@testset "debug level" begin
+    # `debug_level` selects how much exception-reporting code a kernel carries,
+    # independent of the session's `-g` level
+    kernel(a) = (a[2] = 1f0; return)
+    a = OpenCL.zeros(Float32, 1)
+    ir(dl) = sprint(io->(@device_code_llvm io=io @opencl launch=false debug_level=dl kernel(a)))
+    @test !occursin("gpu_report_exception", ir(0))
+    @test occursin("gpu_report_exception", ir(1))
+    @test !occursin("gpu_report_exception_frame", ir(1))
+    @test occursin("gpu_report_exception_frame", ir(2))
+end
+
+@testset "device-side exceptions" begin
+    # a kernel that throws must not wedge the device: it should complete, and surface on
+    # the host as a `KernelException` when synchronizing the queue it ran on.
+    function throwing_kernel(a)
+        a[2] = 1f0      # out-of-bounds store on a length-1 array
+        return
+    end
+    function fill_one(a)
+        a[get_global_id()] = 1f0
+        return
+    end
+
+    a = OpenCL.zeros(Float32, 1)
+    @opencl throwing_kernel(a)
+    @test_throws OpenCL.KernelException cl.finish(cl.queue())
+    # the mailbox is reset on read
+    cl.finish(cl.queue())
+
+    # A context shares one mailbox across queues. Synchronizing either queue must first finish
+    # every queue that may still use it, and may therefore surface the other queue's exception.
+    plain_throwing_kernel() = error("device failure")
+    no_op_kernel() = return
+    q1, q2 = cl.CmdQueue(), cl.CmdQueue()
+    cl.queue!(q1) do
+        @opencl plain_throwing_kernel()
+    end
+    cl.queue!(q2) do
+        @opencl no_op_kernel()
+    end
+    @test_throws OpenCL.KernelException cl.finish(q2)
+    cl.finish(q1)
+
+    # Finalizers synchronize without throwing, but must leave the report available for the
+    # next ordinary synchronization.
+    @opencl throwing_kernel(a)
+    cl.finish(cl.queue(); check_exceptions=false)
+    @test_throws OpenCL.KernelException cl.finish(cl.queue())
+
+    # an exception whose argument needs boxing (a runtime value) must not have its throw
+    # path deleted by the device compiler (JuliaGPU/GPUCompiler.jl#919)
+    function boxed_kernel(a)
+        x = a[1]
+        x == 0 && throw(DomainError(x))
+        return
+    end
+    ir = sprint(io->(@device_code_llvm io=io @opencl launch=false boxed_kernel(a)))
+    @test occursin("gpu_signal_exception", ir)
+    @opencl boxed_kernel(a)
+    @test_throws OpenCL.KernelException cl.finish(cl.queue())
+
+    # a blocking copy of the kernel's output raises instead of returning garbage
+    @opencl throwing_kernel(a)
+    @test_throws OpenCL.KernelException Array(a)
+
+    # the device stays usable afterwards
+    b = OpenCL.zeros(Float32, 4)
+    @opencl global_size=4 fill_one(b)
+    cl.finish(cl.queue())
+    @test Array(b) == ones(Float32, 4)
+
+    # broadcast
+    c = CLArray([1, 0, 1])
+    d = 1 .÷ c
+    @test_throws OpenCL.KernelException Array(d)
+
+    # KernelAbstractions
+    @kernel function ka_throwing_kernel(a)
+        i = @index(Global)
+        a[i+1] = 1f0
+    end
+    e = OpenCL.zeros(Float32, 1)
+    ka_throwing_kernel(OpenCLBackend())(e; ndrange=1)
+    @test_throws OpenCL.KernelException KernelAbstractions.synchronize(OpenCLBackend())
+
+    # devices without host-accessible pointer memory put the mailbox in a mappable buffer
+    # with a device address; exercise that path by swapping in such a mailbox
+    if cl.bda_supported(cl.device())
+        ctx = cl.context()
+        mailbox = OpenCL.allocate_exception_mailbox(ctx; backends=(:buffer,))
+        @test mailbox.mem isa cl.Buffer
+        old = Base.@lock OpenCL.exception_mailboxes_lock begin
+            old = OpenCL.exception_mailboxes[(ctx, cl.device())]
+            OpenCL.exception_mailboxes[(ctx, cl.device())] = mailbox
+            old
+        end
+        try
+            @opencl throwing_kernel(a)
+            @test_throws OpenCL.KernelException cl.finish(cl.queue())
+            cl.finish(cl.queue())
+            @opencl throwing_kernel(a)
+            @test_throws OpenCL.KernelException Array(a)
+        finally
+            Base.@lock OpenCL.exception_mailboxes_lock OpenCL.exception_mailboxes[(ctx, cl.device())] = old
+        end
+    end
+end
+
+@testset "exception reporting per debug level" begin
+    # `@opencl debug_level=` controls how much an exception reports, independent of the
+    # session's `-g` (it's part of the compile cache key, resolved at codegen), so all three
+    # tiers can be checked in one process regardless of how the suite was launched.
+    bounds_oob(a) = (a[2] = 1f0; return)   # out-of-bounds on a length-1 array
+    nonquirk(out, d) = (out[1] = 1 ÷ d[1]; return)   # divide-by-zero -> throw(DivideError())
+    function throw_at(dl, kernel, args...; kwargs...)
+        k = @opencl launch=false debug_level=dl kernel(args...)
+        k(args...; kwargs...)
+        try; cl.finish(cl.queue()); nothing; catch err; err; end
+    end
+
+    # -g0: only that an exception occurred; everything else stays at its sentinel
+    exc0 = throw_at(0, bounds_oob, OpenCL.zeros(Float32, 1))
+    @test exc0 isa OpenCL.KernelException
+    @test isempty(exc0.name)
+    @test isempty(exc0.reason)
+    @test exc0.work_item == (0, 0, 0)
+    @test isempty(exc0.backtrace)
+    @test occursin("debug_level=2", sprint(showerror, exc0))
+
+    # -g1: the faulting type and reason for quirk throws; no position (recording it costs
+    # every kernel that can throw, even when nothing ever does; see `claim_output!`)
+    exc1 = throw_at(1, bounds_oob, OpenCL.zeros(Float32, 1))
+    @test exc1.name == "BoundsError"
+    @test exc1.reason == "Out-of-bounds array access"
+    @test exc1.work_item == (0, 0, 0)
+    @test isempty(exc1.backtrace)
+    @test occursin("A BoundsError was thrown", sprint(showerror, exc1))
+
+    # a non-quirk throw records the compiler-deduced type name (here `jl_throw`'s generic
+    # "exception") only at debug level >= 2: copying that runtime string takes a byte loop
+    # on the unhappy path (see `report_exception`)
+    excn = throw_at(1, nonquirk, OpenCL.zeros(Int32, 1), CLArray(Int32[0]))
+    @test excn isa OpenCL.KernelException
+    @test isempty(excn.name)
+    excn2 = throw_at(2, nonquirk, OpenCL.zeros(Int32, 1), CLArray(Int32[0]))
+    @test excn2.name == "exception"
+
+    # -g2: adds the faulting position and the device stack trace
+    exc2 = throw_at(2, bounds_oob, OpenCL.zeros(Float32, 1))
+    @test exc2.name == "BoundsError"
+    @test exc2.work_item == (1, 1, 1)
+    @test exc2.work_group == (1, 1, 1)
+    @test !isempty(exc2.backtrace)
+    @test any(frame -> occursin("throw_boundserror", frame[1]), exc2.backtrace)
+    @test occursin("by work-item 1×1×1 in work-group 1×1×1", sprint(showerror, exc2))
+
+    # the position identifies the faulting work-item, not the first one
+    function throw_at_three(a)
+        if get_local_id() == 3
+            a[2] = 1f0
+        end
+        return
+    end
+    exc3 = throw_at(2, throw_at_three, OpenCL.zeros(Float32, 1);
+                    global_size=8, local_size=4)
+    @test exc3.work_item == (3, 1, 1)
+    @test exc3.work_group in ((1, 1, 1), (2, 1, 1))
+
+    # quirks that construct their exception without a `throw_*` helper are overridden to
+    # report through the mailbox as well, rather than boxing on the throwing branch
+    bool_kernel(a) = (a[1] = Bool(a[1]); return)
+    excb = throw_at(1, bool_kernel, CLArray(Float32[2]))
+    @test excb.name == "InexactError"
+    exponent_kernel(a) = (a[1] = exponent(a[1]); return)
+    exce = throw_at(1, exponent_kernel, CLArray(Float32[0]))
+    @test exce.name == "DomainError"
+end
+
+@testset "exception report ownership" begin
+    function first_failure()
+        OpenCL.@gputhrow "FirstError" "first kernel"
+        return
+    end
+    function second_failure()
+        OpenCL.@gputhrow "SecondError" "second kernel"
+        return
+    end
+    # Compile before submitting either kernel so compilation cannot trigger a finalizer
+    # that synchronizes in between. The two launches have identical work-item coordinates.
+    first = @opencl launch=false debug_level=2 first_failure()
+    second = @opencl launch=false debug_level=2 second_failure()
+    for separate_queues in (false, true)
+        q1 = cl.CmdQueue()
+        q2 = separate_queues ? cl.CmdQueue() : q1
+        cl.queue!(q1) do
+            first()
+        end
+        # Order the device work without consuming its report.
+        cl.finish(q1; check_exceptions=false)
+        cl.queue!(q2) do
+            second()
+        end
+        exc = try
+            cl.finish(q2)
+            nothing
+        catch err
+            err
+        end
+        @test exc isa OpenCL.KernelException
+        @test exc.name == "FirstError"
+        @test exc.reason == "first kernel"
+        @test any(frame -> occursin("first_failure", frame[1]), exc.backtrace)
+        @test !any(frame -> occursin("second_failure", frame[1]), exc.backtrace)
+        cl.finish(q1)
+    end
+
+    function many_failures()
+        if isodd(get_local_id())
+            OpenCL.@gputhrow "OddError" "odd work-item"
+        else
+            OpenCL.@gputhrow "EvenError" "even work-item"
+        end
+        return
+    end
+    kernel = @opencl launch=false debug_level=2 many_failures()
+    for _ in 1:10
+        kernel(; global_size=256, local_size=32)
+        exc = try
+            cl.finish(cl.queue())
+            nothing
+        catch err
+            err
+        end
+        @test exc isa OpenCL.KernelException
+        odd = isodd(exc.work_item[1])
+        @test exc.name == (odd ? "OddError" : "EvenError")
+        @test exc.reason == (odd ? "odd work-item" : "even work-item")
+        @test 1 <= exc.work_group[1] <= 8
+        @test !isempty(exc.backtrace)
+    end
+end
+
+@testset "concurrent exception checks" begin
+    fail() = error("concurrent failure")
+    kernel = @opencl launch=false debug_level=2 fail()
+    dev = cl.device()
+    queues = [cl.CmdQueue(), cl.CmdQueue()]
+    @sync for queue in queues
+        Threads.@spawn begin
+            cl.device!(dev)
+            cl.queue!(queue) do
+                kernel()
+            end
+        end
+    end
+    errors = Channel{Any}(length(queues))
+    @sync for queue in queues
+        Threads.@spawn begin
+            err = try
+                cl.finish(queue)
+                nothing
+            catch err
+                err
+            end
+            put!(errors, err)
+        end
+    end
+    reports = [take!(errors) for _ in queues]
+    @test count(err -> err isa OpenCL.KernelException, reports) == 1
+    @test count(isnothing, reports) == 1
+    foreach(cl.finish, queues)
+end
+
+@testset "exception mailbox memory" begin
+    fail() = error("mailbox backend")
+    kernel = @opencl launch=false debug_level=2 fail()
+    ctx, dev = cl.context(), cl.device()
+    cl.finish(cl.queue())
+    key = (ctx, dev)
+    old = Base.@lock OpenCL.exception_mailboxes_lock get(OpenCL.exception_mailboxes, key, nothing)
+    try
+        for backend in OpenCL.exception_mailbox_backends
+            supported = backend === :usm ? cl.usm_supported(dev) && cl.usm_capabilities(dev).host.access :
+                        backend === :svm_fine ? cl.svm_capabilities(dev).fine_grain_buffer :
+                        backend === :svm_coarse ? cl.svm_capabilities(dev).coarse_grain_buffer :
+                        cl.bda_supported(dev)
+            supported || continue
+            @testset "$backend" begin
+                mailbox = OpenCL.allocate_exception_mailbox(ctx; backends=(backend,))
+                Base.@lock OpenCL.exception_mailboxes_lock OpenCL.exception_mailboxes[key] = mailbox
+                for _ in 1:2
+                    kernel()
+                    exc = try
+                        cl.finish(cl.queue())
+                        nothing
+                    catch err
+                        err
+                    end
+                    @test exc isa OpenCL.KernelException
+                    @test exc.dev == dev
+                    @test !isempty(exc.backtrace)
+                    cl.finish(cl.queue())
+                end
+            end
+        end
+        # Exercise the zero-address path without requiring an unsupported physical device.
+        mailbox = @test_logs (:warn, r"Device-side exceptions cannot be reported") OpenCL.allocate_exception_mailbox(ctx; backends=())
+        Base.@lock OpenCL.exception_mailboxes_lock OpenCL.exception_mailboxes[key] = mailbox
+        kernel()
+        @test cl.finish(cl.queue()) isa cl.CmdQueue
+    finally
+        Base.@lock OpenCL.exception_mailboxes_lock begin
+            if old === nothing
+                delete!(OpenCL.exception_mailboxes, key)
+            else
+                OpenCL.exception_mailboxes[key] = old
+            end
+        end
+    end
+end
+
+@testset "finalizer synchronization" begin
+    fail() = error("pending finalizer report")
+    @opencl fail()
+    queue = cl.queue()
+    mailbox = OpenCL.exception_mailboxes[(cl.context(), cl.device())]
+    ready, release = Channel{Nothing}(1), Channel{Nothing}(1)
+    holder = @async Base.@lock mailbox.lock begin
+        put!(ready, nothing)
+        take!(release)
+    end
+    take!(ready)
+    try
+        # The finalizer path must not wait on the mailbox lock held by another task.
+        # Release the lock even on failure so a regression cannot hang the test suite.
+        check = @async cl.finish(queue; check_exceptions=false)
+        @test timedwait(() -> istaskdone(check), 5) == :ok
+    finally
+        put!(release, nothing)
+        wait(holder)
+    end
+    @test_throws OpenCL.KernelException cl.finish(queue)
+    cl.finish(queue)
+end


### PR DESCRIPTION
OpenCL kernels can now report failures to the host as `KernelException`s. A faulting
work-item returns, and the error is raised when the host synchronizes, including through
`cl.finish`, blocking copies such as `Array(a)`, and KernelAbstractions synchronization.
The report is consumed before throwing, so subsequent kernels can run normally.

```julia
using OpenCL

a = OpenCL.zeros(Float32, 1)
@opencl debug_level=2 (a -> (a[2] = 1f0; return))(a)
cl.finish(cl.queue())  # KernelException with BoundsError details and a device backtrace
```

The new `debug_level` keyword defaults to Julia's `-g` setting. Level 0 records only that
an exception occurred; level 1 adds names and reasons for common runtime errors; level 2
also records work-item coordinates and a bounded device-side backtrace.

Each device in a context has a mailbox shared by its queues. Synchronizing one queue may
therefore wait for and report an error from another queue on that device. Device atomics
select one writer, identified by its launch and work-item coordinates, so later kernels
cannot overwrite its diagnostics. Finalizer-driven synchronization leaves reports pending
for ordinary host checks.

Mailbox storage uses USM host memory, fine- or coarse-grained SVM, or a mappable buffer
with a device address. Unsupported contexts warn and run without host-side reporting.
Mailbox allocations retain their contexts for the lifetime of the process. Failed kernels
may leave incomplete results, and work-group barriers must still obey convergence rules.

Requires GPUCompiler 2.5.2 for SPIR-V exception lowering, failed-boxing handling, and the
correct address space for diagnostic strings. This supersedes #328 and the earlier
host-side prototype in #342.

Validated with native Intel and NVIDIA drivers, packaged PoCL 7.1 and 7.2, and a local
PoCL build, using both SPIR-V and OpenCL C paths where supported. Tests cover Julia 1.10,
1.12, and 1.13, debug levels, boxed exceptions, blocking copies, concurrent checks,
report ownership, mailbox memory backends, and finalizer synchronization. Documentation
builds successfully.