### PR TITLE
Fix Float16 normal generation and RNG overlay dispatch

### DIFF
--- a/src/device/random.jl
+++ b/src/device/random.jl
@@ -220,8 +220,11 @@ end
     end
 end
 
-@device_override @inline function Random.randn(rng::AbstractRNG, ::Type{T}) where {T <: Union{Float16, Float32}}
-    @invoke Random.randn(rng::AbstractRNG, T::Type{<:AbstractFloat})
+# Use the table-free fallback, but compute it in Float32 because its polar transform can
+# overflow in Float16. Keep this scoped to our RNG: overlay methods take precedence over
+# regular dispatch and an AbstractRNG method would shadow methods for other device RNGs.
+@device_override @inline function Random.randn(rng::Philox2x32, ::Type{T}) where {T <: Union{Float16, Float32}}
+    T(@invoke Random.randn(rng::AbstractRNG, Float32::Type{<:AbstractFloat}))
 end
 
 ## randexp
@@ -245,8 +248,9 @@ end
     end
 end
 
-@device_override @inline function Random.randexp(rng::AbstractRNG, ::Type{T}) where {T <: Union{Float16, Float32}}
-    @invoke Random.randexp(rng::AbstractRNG, T::Type{<:AbstractFloat})
+# Compute through Float32 to avoid requiring Float16 `log1p` support.
+@device_override @inline function Random.randexp(rng::Philox2x32, ::Type{T}) where {T <: Union{Float16, Float32}}
+    T(@invoke Random.randexp(rng::AbstractRNG, Float32::Type{<:AbstractFloat}))
 end
 
 @device_override Random.Sampler(::Type{<:AbstractRNG}, r::AbstractUnitRange{T},

--- a/test/device/random.jl
+++ b/test/device/random.jl
@@ -156,3 +156,27 @@ end
         @test Array(a) == Array(b)
     end
 end
+
+# Cover both OpenCL's device RNG and GPUArrays' `ElementRNG` path for `Complex{Float16}`.
+if Float16 in GPUArraysTestSuite.supported_eltypes(CLArray)
+    @testset "randn(Float16) is finite" begin
+        function kernel(A)
+            Random.seed!(1)
+            tid = get_global_id(1)
+            A[tid] = randn(Float16)
+            return
+        end
+        len = 2^20
+        a = OpenCL.zeros(Float16, len)
+        @opencl global_size=len local_size=256 kernel(a)
+        @test all(isfinite, Array(a))
+    end
+
+    @testset "randn!(Complex{Float16}) is finite" begin
+        rng = OpenCL.GPUArrays.default_rng(CLArray)
+        Random.seed!(rng, 1)
+        A = CLArray{Complex{Float16}}(undef, 4096)
+        randn!(rng, A)
+        @test all(isfinite, Array(A))
+    end
+end


### PR DESCRIPTION
Compute Philox Float16 normals in Float32 before conversion, avoiding overflow in Random's polar fallback. Do the same for randexp to avoid requiring Float16 log1p support.

Scope the typed randn and randexp overlays to Philox2x32. An AbstractRNG overlay otherwise shadows GPUArrays' more-specific ElementRNG method used by generic randn! for Complex{Float16}.