### PR TITLE
Adapt to the library-based SPIRV_LLVM_Backend_jll 23

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,7 +26,6 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 spirv2clc_jll = "f0274c0c-8c8a-59f1-85b7-f7d60330c5fb"
 
 [sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
 SPIRVIntrinsics = {path = "lib/intrinsics"}
 
 [compat]

--- a/Project.toml
+++ b/Project.toml
@@ -26,12 +26,13 @@ StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 spirv2clc_jll = "f0274c0c-8c8a-59f1-85b7-f7d60330c5fb"
 
 [sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
 SPIRVIntrinsics = {path = "lib/intrinsics"}
 
 [compat]
 Adapt = "4"
 GPUArrays = "11.2.1"
-GPUCompiler = "2.5.2"
+GPUCompiler = "2.7"
 KernelAbstractions = "0.9.38"
 LLVM = "9.6"
 LinearAlgebra = "1"
@@ -43,7 +44,7 @@ Random123 = "1.7.1"
 RandomNumbers = "1.6.0"
 Reexport = "1"
 SPIRVIntrinsics = "1.1"
-SPIRV_LLVM_Backend_jll = "22"
+SPIRV_LLVM_Backend_jll = "23"
 SPIRV_Tools_jll = "2025.1"
 StaticArrays = "1"
 julia = "1.10"

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -29,6 +29,7 @@ pocl_jll = "627d6b7a-bbe6-5189-83e7-98cc0a5aeadd"
 pocl_next_jll = "59abdad9-3cfc-5436-8271-411e8cad6b82"
 
 [sources]
+GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
 OpenCL = {path = ".."}
 SPIRVIntrinsics = {path = "../lib/intrinsics"}
 

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -29,7 +29,6 @@ pocl_jll = "627d6b7a-bbe6-5189-83e7-98cc0a5aeadd"
 pocl_next_jll = "59abdad9-3cfc-5436-8271-411e8cad6b82"
 
 [sources]
-GPUCompiler = {url = "https://github.com/JuliaGPU/GPUCompiler.jl", rev = "tb/jll-libraries"}
 OpenCL = {path = ".."}
 SPIRVIntrinsics = {path = "../lib/intrinsics"}
 


### PR DESCRIPTION
JuliaPackaging/Yggdrasil#14727 replaced the `llc`, `lld` and `llvm-downgrade` executables in the GPU LLVM JLLs with shared libraries exposing a small C API, moving the back-ends to LLVM 23 at the same time. JuliaGPU/GPUCompiler.jl#930 makes GPUCompiler call those libraries in-process, and bumps its compat to the new JLL majors. Since this package pins the same JLL, it needs its compat bumped in lockstep, which is what this PR does.

Changes: `SPIRV_LLVM_Backend_jll` compat 22 → 23 and `GPUCompiler` compat → 2.7. OpenCL.jl only references the JLL for `versioninfo`.